### PR TITLE
Add judging equity section

### DIFF
--- a/equity.html
+++ b/equity.html
@@ -124,6 +124,7 @@
       <a href="#tournament-equity">Tournament Equity</a>
       <a href="#reporting">PDU Reporting & Support</a>
       <a href="#content-warnings">Content Warnings & Opt-Outs</a>
+      <a href="#judging">Judging</a>
       <a href="#consequences">Consequences</a>
       <a href="#commitments">Our Commitments</a>
     </nav>
@@ -234,6 +235,23 @@
       </ul>
       <div class="cta-row">
         <span class="chip">Template: “CW: [topic]. Alt case available on request.”</span>
+      </div>
+    </section>
+
+    <!-- Judging -->
+    <section class="glass-card" id="judging">
+      <h3 class="about-header">Judging</h3>
+      <p class="about-preview">
+        Judges safeguard equity in every round. Ballots must reflect the arguments made—not a speaker’s identity, style, or reputation.
+      </p>
+      <ul class="section-list">
+        <li>Evaluate only comparative analysis presented in round.</li>
+        <li>Intervene on equity breaches: pause the round and clarify concerns.</li>
+        <li>Contact the tournament’s Equity team or PDU leadership if violations occur.</li>
+      </ul>
+      <div class="cta-row">
+        <a class="link-chip" href="judging.html">Judging Guide →</a>
+        <a class="link-chip" target="_blank" rel="noopener" href="https://apda.online/code-of-conduct/">APDA Code of Conduct →</a>
       </div>
     </section>
 


### PR DESCRIPTION
## Summary
- expand equity page with a new Judging section detailing impartial adjudication and enforcement responsibilities
- include chip links to judging guide and APDA Code of Conduct
- link the new section in on-page contents navigation

## Testing
- `npx htmlhint equity.html` *(fails: npm error canceled)*
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68afd8f2f38c8322863cf29f46857000