### PR TITLE
feat: add judging indicators to tournaments page

### DIFF
--- a/equity.html
+++ b/equity.html
@@ -124,6 +124,7 @@
       <a href="#tournament-equity">Tournament Equity</a>
       <a href="#reporting">PDU Reporting & Support</a>
       <a href="#content-warnings">Content Warnings & Opt-Outs</a>
+      <a href="#judging">Judging</a>
       <a href="#consequences">Consequences</a>
       <a href="#commitments">Our Commitments</a>
     </nav>
@@ -234,6 +235,23 @@
       </ul>
       <div class="cta-row">
         <span class="chip">Template: “CW: [topic]. Alt case available on request.”</span>
+      </div>
+    </section>
+
+    <!-- Judging -->
+    <section class="glass-card" id="judging">
+      <h3 class="about-header">Judging</h3>
+      <p class="about-preview">
+        Judges safeguard equity in every round. Ballots must reflect the arguments made—not a speaker’s identity, style, or reputation.
+      </p>
+      <ul class="section-list">
+        <li>Evaluate only comparative analysis presented in round.</li>
+        <li>Intervene on equity breaches: pause the round and clarify concerns.</li>
+        <li>Contact the tournament’s Equity team or PDU leadership if violations occur.</li>
+      </ul>
+      <div class="cta-row">
+        <a class="link-chip" href="judging.html">Judging Guide →</a>
+        <a class="link-chip" target="_blank" rel="noopener" href="https://apda.online/code-of-conduct/">APDA Code of Conduct →</a>
       </div>
     </section>
 

--- a/style.css
+++ b/style.css
@@ -243,6 +243,38 @@ nav a:hover{ color:#fff; text-shadow:0 0 8px rgba(199,191,255,.9); }
 .event-meta{ opacity:.9; margin:.1rem 0 .25rem; font-size:.95rem; }
 .event-note{ opacity:.85; font-size:.92rem; margin-bottom:.6rem; }
 
+/* === Tournament badges (judges needed) === */
+.event-badges{
+  display:flex; gap:.4rem; align-items:center; margin:.35rem 0 .25rem;
+}
+
+.badge-need{
+  display:inline-flex; align-items:center; gap:.35rem;
+  padding:.25rem .5rem; border-radius:999px;
+  border:1px solid rgba(255,255,255,.28);
+  background:rgba(255,255,255,.10);
+  font-size:.9rem; line-height:1;
+  backdrop-filter:blur(8px);
+}
+.badge-need .icon{
+  width:14px; height:14px; opacity:.9; display:inline-block;
+  fill:currentColor;
+}
+
+/* State tints */
+.badge-need.need{
+  border-color:rgba(255, 160, 122, .55); /* soft alert */
+  box-shadow:0 0 12px rgba(255,160,122,.22);
+}
+.badge-need.ok{
+  border-color:rgba(144, 238, 144, .45); /* soft good */
+  box-shadow:0 0 10px rgba(144,238,144,.18) inset;
+}
+.badge-need.tbd{
+  border-color:rgba(255,255,255,.28);
+  opacity:.95;
+}
+
 /* ====== Why PDU bullets ====== */
 .points{ margin:.25rem 0 1rem 1.2rem; }
 .points li{ margin:.25rem 0; }

--- a/tournaments.html
+++ b/tournaments.html
@@ -197,6 +197,7 @@
     <nav class="toc-list">
       <a href="#featured" class="active">Featured Tournament</a>
       <a href="#upcoming">Upcoming Targets</a>
+      <a href="#judging">Judging</a>
       <a href="#primer">How APDA Works</a>
       <a href="#eligibility">Eligibility & Selection</a>
       <a href="#tids">TIDs</a>
@@ -213,12 +214,22 @@
     <section class="glass-card reveal" id="featured">
       <div class="feature-card">
         <div class="feature-left">
+          <div class="event-head">
+            <h3>Yale IV (Placeholder)</h3>
+            <span class="pill open">Sign-ups open</span>
+          </div>
+          <div class="event-badges">
+            <span class="badge-need" data-judges-needed="3" title="Estimated judges needed">
+              <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M7.5 7.5l4 4 5-5-4-4-5 5zm-1.4 1.4l-1.1 3.3 3.2-1.2 8-8-2.1-2.1-8 8zM3 21h18v-2H3v2z"/>
+              </svg>
+              <span class="badge-text">Judges needed: <strong class="need-count">3</strong></span>
+            </span>
+          </div>
           <div class="meta">
-            <span class="pill open">Sign-ups Open</span>
             <span class="chip">New Haven, CT</span>
             <span class="chip">Fri–Sat (Placeholder)</span>
           </div>
-          <h3>Yale IV (Placeholder)</h3>
           <p class="muted">A classic early-fall tournament with a large field and a brisk break. Great for motivated pairs and confident novices.</p>
           <ul class="section-list" style="margin-top:.6rem;">
             <li><strong>Interest form closes:</strong> Sep 20, 11:59 PM ET (placeholder)</li>
@@ -226,10 +237,11 @@
             <li><strong>Funding:</strong> PDU covers travel, registration, lodging.</li>
           </ul>
           <div class="cta-row" style="margin-top:.75rem;">
-            <a class="link-chip" href="#" title="Placeholder link for interest form">Interest Form →</a>
+            <a class="link-chip" href="#" title="Placeholder link for interest form" target="_blank" rel="noopener">Interest form →</a>
             <a class="link-chip" href="calendar.html">Add/See on Calendar →</a>
             <a class="link-chip" href="https://drive.google.com/drive/folders/1SIot57czQp_hxY6Bx38I_SN4deVhbvDo?usp=drive_link" target="_blank" rel="noopener">TID (Drive) →</a>
           </div>
+          <p class="note">Sign up to debate <em>or</em> judge — choose your role in the form.</p>
         </div>
 
         <aside class="feature-right">
@@ -250,26 +262,47 @@
       <div class="targets-grid" role="list">
         <!-- Card 1: Sign-ups Open (shows Interest Form) -->
         <article class="target-card" role="listitem">
+          <div class="event-head">
+            <h4>Princeton Invitational</h4>
+            <span class="pill open">Sign-ups open</span>
+          </div>
+          <div class="event-badges">
+            <span class="badge-need" data-judges-needed="tbd" title="Estimated judges needed">
+              <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M7.5 7.5l4 4 5-5-4-4-5 5zm-1.4 1.4l-1.1 3.3 3.2-1.2 8-8-2.1-2.1-8 8zM3 21h18v-2H3v2z"/>
+              </svg>
+              <span class="badge-text">Judges needed: <strong class="need-count">TBD</strong></span>
+            </span>
+          </div>
           <div class="meta">
-            <span class="pill open">Sign-ups Open</span>
             <span class="chip">Oct 3–4 (Placeholder)</span>
           </div>
-          <h4>Princeton Invitational</h4>
           <p class="about-preview" style="margin:.25rem 0 .4rem;">Balanced field, good for new partnerships and experienced teams alike.</p>
           <div class="cta-row">
-            <a class="link-chip" href="#" title="Placeholder link for interest form">Interest Form →</a>
+            <a class="link-chip" href="#" title="Placeholder link for interest form" target="_blank" rel="noopener">Interest form →</a>
             <a class="link-chip" href="calendar.html">Calendar →</a>
             <a class="link-chip" href="https://drive.google.com/drive/folders/1SIot57czQp_hxY6Bx38I_SN4deVhbvDo?usp=drive_link" target="_blank" rel="noopener">TID →</a>
           </div>
+          <p class="note">Sign up to debate <em>or</em> judge — choose your role in the form.</p>
         </article>
 
         <!-- Card 2: Tentative -->
         <article class="target-card" role="listitem">
-          <div class="meta">
+          <div class="event-head">
+            <h4>Harvard Intervarsity</h4>
             <span class="pill tentative">Tentative</span>
+          </div>
+          <div class="event-badges">
+            <span class="badge-need" data-judges-needed="2" title="Estimated judges needed">
+              <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M7.5 7.5l4 4 5-5-4-4-5 5zm-1.4 1.4l-1.1 3.3 3.2-1.2 8-8-2.1-2.1-8 8zM3 21h18v-2H3v2z"/>
+              </svg>
+              <span class="badge-text">Judges needed: <strong class="need-count">2</strong></span>
+            </span>
+          </div>
+          <div class="meta">
             <span class="chip">Oct 24–25 (Placeholder)</span>
           </div>
-          <h4>Harvard Intervarsity</h4>
           <p class="about-preview" style="margin:.25rem 0 .4rem;">Large, competitive field; good for experienced pairs aiming to break.</p>
           <div class="cta-row">
             <a class="link-chip" href="calendar.html">Calendar →</a>
@@ -279,11 +312,21 @@
 
         <!-- Card 3: Confirmed -->
         <article class="target-card" role="listitem">
-          <div class="meta">
+          <div class="event-head">
+            <h4>Columbia Fall Open</h4>
             <span class="pill confirmed">Roster Confirmed</span>
+          </div>
+          <div class="event-badges">
+            <span class="badge-need" data-judges-needed="0" title="Estimated judges needed">
+              <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M7.5 7.5l4 4 5-5-4-4-5 5zm-1.4 1.4l-1.1 3.3 3.2-1.2 8-8-2.1-2.1-8 8zM3 21h18v-2H3v2z"/>
+              </svg>
+              <span class="badge-text">Judges needed: <strong class="need-count">0</strong></span>
+            </span>
+          </div>
+          <div class="meta">
             <span class="chip">Nov 7–8 (Placeholder)</span>
           </div>
-          <h4>Columbia Fall Open</h4>
           <p class="about-preview" style="margin:.25rem 0 .4rem;">Close to home with strong judging pool; good learning weekend.</p>
           <div class="cta-row">
             <a class="link-chip" href="calendar.html">Calendar →</a>
@@ -293,17 +336,45 @@
 
         <!-- Card 4: Tentative -->
         <article class="target-card" role="listitem">
-          <div class="meta">
+          <div class="event-head">
+            <h4>Northeastern Open</h4>
             <span class="pill tentative">Tentative</span>
+          </div>
+          <div class="event-badges">
+            <span class="badge-need" data-judges-needed="1" title="Estimated judges needed">
+              <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M7.5 7.5l4 4 5-5-4-4-5 5zm-1.4 1.4l-1.1 3.3 3.2-1.2 8-8-2.1-2.1-8 8zM3 21h18v-2H3v2z"/>
+              </svg>
+              <span class="badge-text">Judges needed: <strong class="need-count">1</strong></span>
+            </span>
+          </div>
+          <div class="meta">
             <span class="chip">Dec 5–6 (Placeholder)</span>
           </div>
-          <h4>Northeastern Open</h4>
           <p class="about-preview" style="margin:.25rem 0 .4rem;">Great late-semester reps; friendly tournament culture.</p>
           <div class="cta-row">
             <a class="link-chip" href="calendar.html">Calendar →</a>
             <a class="link-chip" href="https://drive.google.com/drive/folders/1SIot57czQp_hxY6Bx38I_SN4deVhbvDo?usp=drive_link" target="_blank" rel="noopener">TID →</a>
           </div>
         </article>
+      </div>
+    </section>
+
+    <!-- Judging info -->
+    <section class="glass-card reveal" id="judging">
+      <h3 class="about-header">Judging</h3>
+      <p class="about-preview">
+        Great rounds need great judges. You can sign up to judge using the same interest form as debaters—just select “Judge.” We’ll provide a quick briefing, a timer, and a flow sheet. No prior APDA experience required.
+      </p>
+      <ul class="section-list">
+        <li><strong>Before:</strong> Read the case statement, note any CWs, track protected time.</li>
+        <li><strong>During:</strong> Flow key claims and responses, weigh clearly; watch for valid POOs.</li>
+        <li><strong>After:</strong> Give a concise Reason for Decision and fair speaks.</li>
+      </ul>
+      <div class="cta-row">
+        <a class="link-chip" href="judging.html">Judging Guide →</a>
+        <a class="link-chip" href="practicetools.html#timer">Open speech timer →</a>
+        <a class="link-chip" href="calendar.html">See tournament dates →</a>
       </div>
     </section>
 
@@ -483,6 +554,27 @@
       for (const s of sections) { if (s.offsetTop <= y) current = s.id; }
       tocLinks.forEach(a => a.classList.toggle('active', a.getAttribute('href') === '#' + current));
     }, { passive: true });
+  </script>
+  <script>
+    document.querySelectorAll('.badge-need').forEach(b => {
+      const raw = (b.getAttribute('data-judges-needed') || '').toLowerCase().trim();
+      const countEl = b.querySelector('.need-count');
+      if (!countEl) return;
+      if (!raw || raw === 'tbd') {
+        countEl.textContent = 'TBD';
+        b.classList.remove('ok'); b.classList.add('tbd');
+      } else {
+        const n = Number(raw);
+        if (Number.isFinite(n)) {
+          countEl.textContent = n;
+          if (n > 0) { b.classList.remove('ok','tbd'); b.classList.add('need'); }
+          else { b.classList.remove('need','tbd'); b.classList.add('ok'); countEl.textContent = 'Covered'; }
+        } else {
+          countEl.textContent = 'TBD';
+          b.classList.remove('ok'); b.classList.add('tbd');
+        }
+      }
+    });
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add judges-needed badges with gavel icon to featured and upcoming tournament cards
- include dedicated Judging info card and link in page contents
- support badges with lightweight JS and new utility styles

## Testing
- `npx htmlhint tournaments.html`
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68afd8f2f38c8322863cf29f46857000