### PR TITLE
Streamline navigation and fix mobile dropdown

### DIFF
--- a/about.html
+++ b/about.html
@@ -37,6 +37,7 @@
           <li class="has-submenu">
             <a href="tournaments.html" class="top-link" aria-haspopup="true" aria-expanded="false">Tournaments</a>
             <ul class="submenu" role="menu" aria-label="Tournaments submenu">
+              <li role="none"><a role="menuitem" href="tournaments.html#featured">Next Tournament</a></li>
               <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
             </ul>
           </li>
@@ -46,11 +47,10 @@
             <ul class="submenu" role="menu" aria-label="Join Us submenu">
               <li role="none"><a role="menuitem" href="join.html#mailing">Mailing List</a></li>
               <li role="none"><a role="menuitem" href="join.html#meetings">Meetings</a></li>
-              <li role="none"><a role="menuitem" href="join.html#calendar">Calendar</a></li>
               <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
               <li role="none"><a role="menuitem" href="practicetools.html">Practice Tools</a></li>
               <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
-              <li role="none"><a role="menuitem" href="resources.html">Resource Library</a></li>
+              <li role="none"><a role="menuitem" href="resources.html">Resources Library</a></li>
             </ul>
           </li>
 
@@ -96,6 +96,7 @@
         <li class="drawer-group">
           <button class="drawer-toggle" aria-expanded="false">Tournaments</button>
           <ul class="drawer-submenu">
+            <li><a href="tournaments.html#featured">Next Tournament</a></li>
             <li><a href="tournaments.html">Upcoming</a></li>
             <li><a href="calendar.html">Calendar</a></li>
           </ul>
@@ -106,11 +107,10 @@
           <ul class="drawer-submenu">
             <li><a href="join.html#mailing">Mailing List</a></li>
             <li><a href="join.html#meetings">Meetings</a></li>
-            <li><a href="join.html#calendar">Calendar</a></li>
             <li><a href="beginner.html">Beginners Guide</a></li>
             <li><a href="practicetools.html">Practice Tools</a></li>
             <li><a href="calendar.html">Calendar</a></li>
-            <li><a href="resources.html">Resource Library</a></li>
+            <li><a href="resources.html">Resources Library</a></li>
           </ul>
         </li>
 

--- a/beginner.html
+++ b/beginner.html
@@ -166,6 +166,7 @@
           <li class="has-submenu">
             <a href="tournaments.html" class="top-link" aria-haspopup="true" aria-expanded="false">Tournaments</a>
             <ul class="submenu" role="menu" aria-label="Tournaments submenu">
+              <li role="none"><a role="menuitem" href="tournaments.html#featured">Next Tournament</a></li>
               <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
             </ul>
           </li>
@@ -175,11 +176,10 @@
             <ul class="submenu" role="menu" aria-label="Join Us submenu">
               <li role="none"><a role="menuitem" href="join.html#mailing">Mailing List</a></li>
               <li role="none"><a role="menuitem" href="join.html#meetings">Meetings</a></li>
-              <li role="none"><a role="menuitem" href="join.html#calendar">Calendar</a></li>
               <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
               <li role="none"><a role="menuitem" href="practicetools.html">Practice Tools</a></li>
               <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
-              <li role="none"><a role="menuitem" href="resources.html">Resource Library</a></li>
+              <li role="none"><a role="menuitem" href="resources.html">Resources Library</a></li>
             </ul>
           </li>
 
@@ -223,6 +223,7 @@
         <li class="drawer-group">
           <button class="drawer-toggle" aria-expanded="false">Tournaments</button>
           <ul class="drawer-submenu">
+            <li><a href="tournaments.html#featured">Next Tournament</a></li>
             <li><a href="tournaments.html">Upcoming</a></li>
             <li><a href="calendar.html">Calendar</a></li>
           </ul>
@@ -233,11 +234,10 @@
           <ul class="drawer-submenu">
             <li><a href="join.html#mailing">Mailing List</a></li>
             <li><a href="join.html#meetings">Meetings</a></li>
-            <li><a href="join.html#calendar">Calendar</a></li>
             <li><a href="beginner.html">Beginners Guide</a></li>
             <li><a href="practicetools.html">Practice Tools</a></li>
             <li><a href="calendar.html">Calendar</a></li>
-            <li><a href="resources.html">Resource Library</a></li>
+            <li><a href="resources.html">Resources Library</a></li>
           </ul>
         </li>
 

--- a/calendar.html
+++ b/calendar.html
@@ -42,6 +42,7 @@
           <li class="has-submenu">
             <a href="tournaments.html" class="top-link" aria-haspopup="true" aria-expanded="false">Tournaments</a>
             <ul class="submenu" role="menu" aria-label="Tournaments submenu">
+              <li role="none"><a role="menuitem" href="tournaments.html#featured">Next Tournament</a></li>
               <li role="none"><a role="menuitem" href="calendar.html" aria-current="page">Calendar</a></li>
             </ul>
           </li>
@@ -51,11 +52,10 @@
             <ul class="submenu" role="menu" aria-label="Join Us submenu">
               <li role="none"><a role="menuitem" href="join.html#mailing">Mailing List</a></li>
               <li role="none"><a role="menuitem" href="join.html#meetings">Meetings</a></li>
-              <li role="none"><a role="menuitem" href="join.html#calendar">Calendar</a></li>
               <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
               <li role="none"><a role="menuitem" href="practicetools.html">Practice Tools</a></li>
               <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
-              <li role="none"><a role="menuitem" href="resources.html">Resource Library</a></li>
+              <li role="none"><a role="menuitem" href="resources.html">Resources Library</a></li>
             </ul>
           </li>
 
@@ -97,6 +97,7 @@
         <li class="drawer-group">
           <button class="drawer-toggle" aria-expanded="false">Tournaments</button>
           <ul class="drawer-submenu">
+            <li><a href="tournaments.html#featured">Next Tournament</a></li>
             <li><a href="tournaments.html">Upcoming</a></li>
             <li><a href="calendar.html">Calendar</a></li>
           </ul>
@@ -107,11 +108,10 @@
           <ul class="drawer-submenu">
             <li><a href="join.html#mailing">Mailing List</a></li>
             <li><a href="join.html#meetings">Meetings</a></li>
-            <li><a href="join.html#calendar">Calendar</a></li>
             <li><a href="beginner.html">Beginners Guide</a></li>
             <li><a href="practicetools.html">Practice Tools</a></li>
             <li><a href="calendar.html">Calendar</a></li>
-            <li><a href="resources.html">Resource Library</a></li>
+            <li><a href="resources.html">Resources Library</a></li>
           </ul>
         </li>
 
@@ -178,6 +178,23 @@
     burger.addEventListener('click', toggleDrawer);
     closeBtn.addEventListener('click', closeDrawer);
     scrim.addEventListener('click', closeDrawer);
+
+    document.querySelectorAll('.drawer-toggle').forEach(btn=>{
+      btn.addEventListener('click',()=>{
+        const ex = btn.getAttribute('aria-expanded')==='true';
+        btn.setAttribute('aria-expanded', String(!ex));
+        btn.nextElementSibling.classList.toggle('open');
+      });
+    });
+
+    document.querySelectorAll('.has-submenu').forEach(item=>{
+      const link=item.querySelector('.top-link');
+      item.addEventListener('mouseenter',()=>link.setAttribute('aria-expanded','true'));
+      item.addEventListener('mouseleave',()=>link.setAttribute('aria-expanded','false'));
+      link.addEventListener('focus',()=>link.setAttribute('aria-expanded','true'));
+      const sm=item.querySelector('.submenu');
+      sm.addEventListener('keydown',e=>{ if(e.key==='Escape'){ link.focus(); link.setAttribute('aria-expanded','false'); } });
+    });
 
     // Reveal effect for cards
     const observer = new IntersectionObserver(entries => {

--- a/contact.html
+++ b/contact.html
@@ -127,6 +127,7 @@
           <li class="has-submenu">
             <a href="tournaments.html" class="top-link" aria-haspopup="true" aria-expanded="false">Tournaments</a>
             <ul class="submenu" role="menu" aria-label="Tournaments submenu">
+              <li role="none"><a role="menuitem" href="tournaments.html#featured">Next Tournament</a></li>
               <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
             </ul>
           </li>
@@ -136,11 +137,10 @@
             <ul class="submenu" role="menu" aria-label="Join Us submenu">
               <li role="none"><a role="menuitem" href="join.html#mailing">Mailing List</a></li>
               <li role="none"><a role="menuitem" href="join.html#meetings">Meetings</a></li>
-              <li role="none"><a role="menuitem" href="join.html#calendar">Calendar</a></li>
               <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
               <li role="none"><a role="menuitem" href="practicetools.html">Practice Tools</a></li>
               <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
-              <li role="none"><a role="menuitem" href="resources.html">Resource Library</a></li>
+              <li role="none"><a role="menuitem" href="resources.html">Resources Library</a></li>
             </ul>
           </li>
 
@@ -186,6 +186,7 @@
         <li class="drawer-group">
           <button class="drawer-toggle" aria-expanded="false">Tournaments</button>
           <ul class="drawer-submenu">
+            <li><a href="tournaments.html#featured">Next Tournament</a></li>
             <li><a href="tournaments.html">Upcoming</a></li>
             <li><a href="calendar.html">Calendar</a></li>
           </ul>
@@ -196,11 +197,10 @@
           <ul class="drawer-submenu">
             <li><a href="join.html#mailing">Mailing List</a></li>
             <li><a href="join.html#meetings">Meetings</a></li>
-            <li><a href="join.html#calendar">Calendar</a></li>
             <li><a href="beginner.html">Beginners Guide</a></li>
             <li><a href="practicetools.html">Practice Tools</a></li>
             <li><a href="calendar.html">Calendar</a></li>
-            <li><a href="resources.html">Resource Library</a></li>
+            <li><a href="resources.html">Resources Library</a></li>
           </ul>
         </li>
 
@@ -399,6 +399,15 @@
     burger.addEventListener('click', toggleDrawer);
     closeBtn.addEventListener('click', closeDrawer);
     scrim.addEventListener('click', closeDrawer);
+
+    document.querySelectorAll('.drawer-toggle').forEach(btn=>{
+      btn.addEventListener('click',()=>{
+        const ex = btn.getAttribute('aria-expanded')==='true';
+        btn.setAttribute('aria-expanded', String(!ex));
+        btn.nextElementSibling.classList.toggle('open');
+      });
+    });
+
     window.addEventListener('keydown', e => { if(e.key==='Escape' && drawer.classList.contains('open')) closeDrawer(); });
 
     // Desktop submenu accessibility

--- a/equity.html
+++ b/equity.html
@@ -37,6 +37,7 @@
           <li class="has-submenu">
             <a href="tournaments.html" class="top-link" aria-haspopup="true" aria-expanded="false">Tournaments</a>
             <ul class="submenu" role="menu" aria-label="Tournaments submenu">
+              <li role="none"><a role="menuitem" href="tournaments.html#featured">Next Tournament</a></li>
               <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
             </ul>
           </li>
@@ -46,11 +47,10 @@
             <ul class="submenu" role="menu" aria-label="Join Us submenu">
               <li role="none"><a role="menuitem" href="join.html#mailing">Mailing List</a></li>
               <li role="none"><a role="menuitem" href="join.html#meetings">Meetings</a></li>
-              <li role="none"><a role="menuitem" href="join.html#calendar">Calendar</a></li>
               <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
               <li role="none"><a role="menuitem" href="practicetools.html">Practice Tools</a></li>
               <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
-              <li role="none"><a role="menuitem" href="resources.html">Resource Library</a></li>
+              <li role="none"><a role="menuitem" href="resources.html">Resources Library</a></li>
             </ul>
           </li>
 
@@ -96,6 +96,7 @@
         <li class="drawer-group">
           <button class="drawer-toggle" aria-expanded="false">Tournaments</button>
           <ul class="drawer-submenu">
+            <li><a href="tournaments.html#featured">Next Tournament</a></li>
             <li><a href="tournaments.html">Upcoming</a></li>
             <li><a href="calendar.html">Calendar</a></li>
           </ul>
@@ -106,11 +107,10 @@
           <ul class="drawer-submenu">
             <li><a href="join.html#mailing">Mailing List</a></li>
             <li><a href="join.html#meetings">Meetings</a></li>
-            <li><a href="join.html#calendar">Calendar</a></li>
             <li><a href="beginner.html">Beginners Guide</a></li>
             <li><a href="practicetools.html">Practice Tools</a></li>
             <li><a href="calendar.html">Calendar</a></li>
-            <li><a href="resources.html">Resource Library</a></li>
+            <li><a href="resources.html">Resources Library</a></li>
           </ul>
         </li>
 

--- a/index.html
+++ b/index.html
@@ -38,6 +38,7 @@
           <li class="has-submenu">
             <a href="tournaments.html" class="top-link" aria-haspopup="true" aria-expanded="false">Tournaments</a>
             <ul class="submenu" role="menu" aria-label="Tournaments submenu">
+              <li role="none"><a role="menuitem" href="tournaments.html#featured">Next Tournament</a></li>
               <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
             </ul>
           </li>
@@ -47,11 +48,10 @@
             <ul class="submenu" role="menu" aria-label="Join Us submenu">
               <li role="none"><a role="menuitem" href="join.html#mailing">Mailing List</a></li>
               <li role="none"><a role="menuitem" href="join.html#meetings">Meetings</a></li>
-              <li role="none"><a role="menuitem" href="join.html#calendar">Calendar</a></li>
               <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
               <li role="none"><a role="menuitem" href="practicetools.html">Practice Tools</a></li>
               <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
-              <li role="none"><a role="menuitem" href="resources.html">Resource Library</a></li>
+              <li role="none"><a role="menuitem" href="resources.html">Resources Library</a></li>
             </ul>
           </li>
 
@@ -97,6 +97,7 @@
         <li class="drawer-group">
           <button class="drawer-toggle" aria-expanded="false">Tournaments</button>
           <ul class="drawer-submenu">
+            <li><a href="tournaments.html#featured">Next Tournament</a></li>
             <li><a href="tournaments.html">Upcoming</a></li>
             <li><a href="calendar.html">Calendar</a></li>
           </ul>
@@ -107,11 +108,10 @@
           <ul class="drawer-submenu">
             <li><a href="join.html#mailing">Mailing List</a></li>
             <li><a href="join.html#meetings">Meetings</a></li>
-            <li><a href="join.html#calendar">Calendar</a></li>
             <li><a href="beginner.html">Beginners Guide</a></li>
             <li><a href="practicetools.html">Practice Tools</a></li>
             <li><a href="calendar.html">Calendar</a></li>
-            <li><a href="resources.html">Resource Library</a></li>
+            <li><a href="resources.html">Resources Library</a></li>
           </ul>
         </li>
 

--- a/join.html
+++ b/join.html
@@ -189,6 +189,7 @@
           <li class="has-submenu">
             <a href="tournaments.html" class="top-link" aria-haspopup="true" aria-expanded="false">Tournaments</a>
             <ul class="submenu" role="menu" aria-label="Tournaments submenu">
+              <li role="none"><a role="menuitem" href="tournaments.html#featured">Next Tournament</a></li>
               <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
             </ul>
           </li>
@@ -198,11 +199,10 @@
             <ul class="submenu" role="menu" aria-label="Join Us submenu">
               <li role="none"><a role="menuitem" href="join.html#mailing">Mailing List</a></li>
               <li role="none"><a role="menuitem" href="join.html#meetings">Meetings</a></li>
-              <li role="none"><a role="menuitem" href="join.html#calendar">Calendar</a></li>
               <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
               <li role="none"><a role="menuitem" href="practicetools.html">Practice Tools</a></li>
               <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
-              <li role="none"><a role="menuitem" href="resources.html">Resource Library</a></li>
+              <li role="none"><a role="menuitem" href="resources.html">Resources Library</a></li>
             </ul>
           </li>
 
@@ -246,6 +246,7 @@
         <li class="drawer-group">
           <button class="drawer-toggle" aria-expanded="false">Tournaments</button>
           <ul class="drawer-submenu">
+            <li><a href="tournaments.html#featured">Next Tournament</a></li>
             <li><a href="tournaments.html">Upcoming</a></li>
             <li><a href="calendar.html">Calendar</a></li>
           </ul>
@@ -256,11 +257,10 @@
           <ul class="drawer-submenu">
             <li><a href="join.html#mailing">Mailing List</a></li>
             <li><a href="join.html#meetings">Meetings</a></li>
-            <li><a href="join.html#calendar">Calendar</a></li>
             <li><a href="beginner.html">Beginners Guide</a></li>
             <li><a href="practicetools.html">Practice Tools</a></li>
             <li><a href="calendar.html">Calendar</a></li>
-            <li><a href="resources.html">Resource Library</a></li>
+            <li><a href="resources.html">Resources Library</a></li>
           </ul>
         </li>
 

--- a/judging.html
+++ b/judging.html
@@ -202,6 +202,7 @@
           <li class="has-submenu">
             <a href="tournaments.html" class="top-link" aria-haspopup="true" aria-expanded="false">Tournaments</a>
             <ul class="submenu" role="menu" aria-label="Tournaments submenu">
+              <li role="none"><a role="menuitem" href="tournaments.html#featured">Next Tournament</a></li>
               <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
             </ul>
           </li>
@@ -211,11 +212,10 @@
             <ul class="submenu" role="menu" aria-label="Join Us submenu">
               <li role="none"><a role="menuitem" href="join.html#mailing">Mailing List</a></li>
               <li role="none"><a role="menuitem" href="join.html#meetings">Meetings</a></li>
-              <li role="none"><a role="menuitem" href="join.html#calendar">Calendar</a></li>
               <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
               <li role="none"><a role="menuitem" href="practicetools.html">Practice Tools</a></li>
               <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
-              <li role="none"><a role="menuitem" href="resources.html">Resource Library</a></li>
+              <li role="none"><a role="menuitem" href="resources.html">Resources Library</a></li>
             </ul>
           </li>
 
@@ -259,6 +259,7 @@
         <li class="drawer-group">
           <button class="drawer-toggle" aria-expanded="false">Tournaments</button>
           <ul class="drawer-submenu">
+            <li><a href="tournaments.html#featured">Next Tournament</a></li>
             <li><a href="tournaments.html">Upcoming</a></li>
             <li><a href="calendar.html">Calendar</a></li>
           </ul>
@@ -269,11 +270,10 @@
           <ul class="drawer-submenu">
             <li><a href="join.html#mailing">Mailing List</a></li>
             <li><a href="join.html#meetings">Meetings</a></li>
-            <li><a href="join.html#calendar">Calendar</a></li>
             <li><a href="beginner.html">Beginners Guide</a></li>
             <li><a href="practicetools.html">Practice Tools</a></li>
             <li><a href="calendar.html">Calendar</a></li>
-            <li><a href="resources.html">Resource Library</a></li>
+            <li><a href="resources.html">Resources Library</a></li>
           </ul>
         </li>
 

--- a/leadership.html
+++ b/leadership.html
@@ -37,6 +37,7 @@
           <li class="has-submenu">
             <a href="tournaments.html" class="top-link" aria-haspopup="true" aria-expanded="false">Tournaments</a>
             <ul class="submenu" role="menu" aria-label="Tournaments submenu">
+              <li role="none"><a role="menuitem" href="tournaments.html#featured">Next Tournament</a></li>
               <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
             </ul>
           </li>
@@ -46,11 +47,10 @@
             <ul class="submenu" role="menu" aria-label="Join Us submenu">
               <li role="none"><a role="menuitem" href="join.html#mailing">Mailing List</a></li>
               <li role="none"><a role="menuitem" href="join.html#meetings">Meetings</a></li>
-              <li role="none"><a role="menuitem" href="join.html#calendar">Calendar</a></li>
               <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
               <li role="none"><a role="menuitem" href="practicetools.html">Practice Tools</a></li>
               <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
-              <li role="none"><a role="menuitem" href="resources.html">Resource Library</a></li>
+              <li role="none"><a role="menuitem" href="resources.html">Resources Library</a></li>
             </ul>
           </li>
 
@@ -96,6 +96,7 @@
         <li class="drawer-group">
           <button class="drawer-toggle" aria-expanded="false">Tournaments</button>
           <ul class="drawer-submenu">
+            <li><a href="tournaments.html#featured">Next Tournament</a></li>
             <li><a href="tournaments.html">Upcoming</a></li>
             <li><a href="calendar.html">Calendar</a></li>
           </ul>
@@ -106,11 +107,10 @@
           <ul class="drawer-submenu">
             <li><a href="join.html#mailing">Mailing List</a></li>
             <li><a href="join.html#meetings">Meetings</a></li>
-            <li><a href="join.html#calendar">Calendar</a></li>
             <li><a href="beginner.html">Beginners Guide</a></li>
             <li><a href="practicetools.html">Practice Tools</a></li>
             <li><a href="calendar.html">Calendar</a></li>
-            <li><a href="resources.html">Resource Library</a></li>
+            <li><a href="resources.html">Resources Library</a></li>
           </ul>
         </li>
 

--- a/practicetools.html
+++ b/practicetools.html
@@ -231,6 +231,7 @@
           <li class="has-submenu">
             <a href="tournaments.html" class="top-link" aria-haspopup="true" aria-expanded="false">Tournaments</a>
             <ul class="submenu" role="menu" aria-label="Tournaments submenu">
+              <li role="none"><a role="menuitem" href="tournaments.html#featured">Next Tournament</a></li>
               <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
             </ul>
           </li>
@@ -240,11 +241,10 @@
             <ul class="submenu" role="menu" aria-label="Join Us submenu">
               <li role="none"><a role="menuitem" href="join.html#mailing">Mailing List</a></li>
               <li role="none"><a role="menuitem" href="join.html#meetings">Meetings</a></li>
-              <li role="none"><a role="menuitem" href="join.html#calendar">Calendar</a></li>
               <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
               <li role="none"><a role="menuitem" href="practicetools.html" aria-current="page">Practice Tools</a></li>
               <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
-              <li role="none"><a role="menuitem" href="resources.html">Resource Library</a></li>
+              <li role="none"><a role="menuitem" href="resources.html">Resources Library</a></li>
             </ul>
           </li>
 
@@ -288,6 +288,7 @@
         <li class="drawer-group">
           <button class="drawer-toggle" aria-expanded="false">Tournaments</button>
           <ul class="drawer-submenu">
+            <li><a href="tournaments.html#featured">Next Tournament</a></li>
             <li><a href="tournaments.html">Upcoming</a></li>
             <li><a href="calendar.html">Calendar</a></li>
           </ul>
@@ -298,11 +299,10 @@
           <ul class="drawer-submenu">
             <li><a href="join.html#mailing">Mailing List</a></li>
             <li><a href="join.html#meetings">Meetings</a></li>
-            <li><a href="join.html#calendar">Calendar</a></li>
             <li><a href="beginner.html">Beginners Guide</a></li>
             <li><a href="practicetools.html">Practice Tools</a></li>
             <li><a href="calendar.html">Calendar</a></li>
-            <li><a href="resources.html">Resource Library</a></li>
+            <li><a href="resources.html">Resources Library</a></li>
           </ul>
         </li>
 

--- a/resources.html
+++ b/resources.html
@@ -157,6 +157,7 @@
           <li class="has-submenu">
             <a href="tournaments.html" class="top-link" aria-haspopup="true" aria-expanded="false">Tournaments</a>
             <ul class="submenu" role="menu" aria-label="Tournaments submenu">
+              <li role="none"><a role="menuitem" href="tournaments.html#featured">Next Tournament</a></li>
               <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
             </ul>
           </li>
@@ -166,11 +167,10 @@
             <ul class="submenu" role="menu" aria-label="Join Us submenu">
               <li role="none"><a role="menuitem" href="join.html#mailing">Mailing List</a></li>
               <li role="none"><a role="menuitem" href="join.html#meetings">Meetings</a></li>
-              <li role="none"><a role="menuitem" href="join.html#calendar">Calendar</a></li>
               <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
               <li role="none"><a role="menuitem" href="practicetools.html">Practice Tools</a></li>
               <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
-              <li role="none"><a role="menuitem" href="resources.html" aria-current="page">Resource Library</a></li>
+              <li role="none"><a role="menuitem" href="resources.html" aria-current="page">Resources Library</a></li>
             </ul>
           </li>
 
@@ -214,6 +214,7 @@
         <li class="drawer-group">
           <button class="drawer-toggle" aria-expanded="false">Tournaments</button>
           <ul class="drawer-submenu">
+            <li><a href="tournaments.html#featured">Next Tournament</a></li>
             <li><a href="tournaments.html">Upcoming</a></li>
             <li><a href="calendar.html">Calendar</a></li>
           </ul>
@@ -224,11 +225,10 @@
           <ul class="drawer-submenu">
             <li><a href="join.html#mailing">Mailing List</a></li>
             <li><a href="join.html#meetings">Meetings</a></li>
-            <li><a href="join.html#calendar">Calendar</a></li>
             <li><a href="beginner.html">Beginners Guide</a></li>
             <li><a href="practicetools.html">Practice Tools</a></li>
             <li><a href="calendar.html">Calendar</a></li>
-            <li><a href="resources.html">Resource Library</a></li>
+            <li><a href="resources.html">Resources Library</a></li>
           </ul>
         </li>
 

--- a/tournaments.html
+++ b/tournaments.html
@@ -105,6 +105,7 @@
           <li class="has-submenu">
             <a href="tournaments.html" class="top-link" aria-haspopup="true" aria-expanded="false" aria-current="page">Tournaments</a>
             <ul class="submenu" role="menu" aria-label="Tournaments submenu">
+              <li role="none"><a role="menuitem" href="tournaments.html#featured">Next Tournament</a></li>
               <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
             </ul>
           </li>
@@ -114,11 +115,10 @@
             <ul class="submenu" role="menu" aria-label="Join Us submenu">
               <li role="none"><a role="menuitem" href="join.html#mailing">Mailing List</a></li>
               <li role="none"><a role="menuitem" href="join.html#meetings">Meetings</a></li>
-              <li role="none"><a role="menuitem" href="join.html#calendar">Calendar</a></li>
               <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
               <li role="none"><a role="menuitem" href="practicetools.html">Practice Tools</a></li>
               <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
-              <li role="none"><a role="menuitem" href="resources.html">Resource Library</a></li>
+              <li role="none"><a role="menuitem" href="resources.html">Resources Library</a></li>
             </ul>
           </li>
 
@@ -162,6 +162,7 @@
         <li class="drawer-group">
           <button class="drawer-toggle" aria-expanded="false">Tournaments</button>
           <ul class="drawer-submenu">
+            <li><a href="tournaments.html#featured">Next Tournament</a></li>
             <li><a href="tournaments.html">Upcoming</a></li>
             <li><a href="calendar.html">Calendar</a></li>
           </ul>
@@ -172,11 +173,10 @@
           <ul class="drawer-submenu">
             <li><a href="join.html#mailing">Mailing List</a></li>
             <li><a href="join.html#meetings">Meetings</a></li>
-            <li><a href="join.html#calendar">Calendar</a></li>
             <li><a href="beginner.html">Beginners Guide</a></li>
             <li><a href="practicetools.html">Practice Tools</a></li>
             <li><a href="calendar.html">Calendar</a></li>
-            <li><a href="resources.html">Resource Library</a></li>
+            <li><a href="resources.html">Resources Library</a></li>
           </ul>
         </li>
 
@@ -525,6 +525,15 @@
     burger.addEventListener('click', toggleDrawer);
     closeBtn.addEventListener('click', closeDrawer);
     scrim.addEventListener('click', closeDrawer);
+
+    document.querySelectorAll('.drawer-toggle').forEach(btn=>{
+      btn.addEventListener('click',()=>{
+        const ex = btn.getAttribute('aria-expanded')==='true';
+        btn.setAttribute('aria-expanded', String(!ex));
+        btn.nextElementSibling.classList.toggle('open');
+      });
+    });
+
     window.addEventListener('keydown', e => { if(e.key==='Escape' && drawer.classList.contains('open')) closeDrawer(); });
 
     // Desktop submenu a11y


### PR DESCRIPTION
## Summary
- add "Next Tournament" link under Tournaments menu
- clean Join Us menu, leaving a single calendar link and renaming Resources Library
- fix mobile drawer toggles on pages missing the script

## Testing
- `npx --yes htmlhint about.html beginner.html calendar.html contact.html equity.html index.html join.html judging.html leadership.html practicetools.html resources.html tournaments.html`

------
https://chatgpt.com/codex/tasks/task_e_68afed8351108322ae371aa523951431