### PR TITLE
Fix countdown timezone handling for countdown clocks

### DIFF
--- a/index.html
+++ b/index.html
@@ -408,6 +408,9 @@
     }
     function zonedNYToDate(y,m,d,h,mi,s){
       const tz='America/New_York';
+      if(Intl.DateTimeFormat().resolvedOptions().timeZone===tz){
+        return new Date(y, m-1, d, h, mi, s||0);
+      }
       const wall=new Date(Date.UTC(y,m-1,d,h,mi,s||0));
       const inv=new Date(wall.toLocaleString('en-US',{timeZone:tz}));
       const diff=inv.getTime()-wall.getTime();

--- a/join.html
+++ b/join.html
@@ -566,6 +566,9 @@
     }
     function zonedNYToDate(y,m,d,h,mi,s){
       const tz='America/New_York';
+      if(Intl.DateTimeFormat().resolvedOptions().timeZone===tz){
+        return new Date(y, m-1, d, h, mi, s||0);
+      }
       const wall=new Date(Date.UTC(y,m-1,d,h,mi,s||0));
       const inv=new Date(wall.toLocaleString('en-US',{timeZone:tz}));
       const diff=inv.getTime()-wall.getTime();


### PR DESCRIPTION
## Summary
- prevent countdown clocks from miscalculating when client is already in America/New_York
- use local Date directly when browser timezone is Eastern

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aff7b9d4b083228895bb9e7aff5bf2