### PR TITLE
Swap desktop navbar logos and add Members link

### DIFF
--- a/about.html
+++ b/about.html
@@ -64,14 +64,16 @@
           </li>
 
           <li><a href="leadership.html">Leadership</a></li>
+          <li><a href="members.html">Members</a></li>
           <li><a href="contact.html">Contact</a></li>
         </ul>
       </nav>
 
       <!-- PDU logo (left on desktop; centered on mobile) -->
       <div class="nav-left">
-        <a href="index.html" aria-label="Home">
+        <a href="index.html" aria-label="Home" class="brand-link">
           <img src="PDULOGO_Trans.png" alt="PDU Logo" class="logo-pdu" />
+          <span class="brand-text">NYU | PDU</span>
         </a>
       </div>
 
@@ -124,6 +126,7 @@
         </li>
 
         <li><a href="leadership.html">Leadership</a></li>
+        <li><a href="members.html">Members</a></li>
         <li><a href="contact.html">Contact</a></li>
       </ul>
     </nav>

--- a/beginner.html
+++ b/beginner.html
@@ -193,13 +193,15 @@
           </li>
 
           <li><a href="leadership.html">Leadership</a></li>
+          <li><a href="members.html">Members</a></li>
           <li><a href="contact.html">Contact</a></li>
         </ul>
       </nav>
 
       <div class="nav-left">
-        <a href="index.html" aria-label="Home">
+        <a href="index.html" aria-label="Home" class="brand-link">
           <img src="PDULOGO_Trans.png" alt="PDU Logo" class="logo-pdu" />
+          <span class="brand-text">NYU | PDU</span>
         </a>
       </div>
 
@@ -251,6 +253,7 @@
         </li>
 
         <li><a href="leadership.html">Leadership</a></li>
+        <li><a href="members.html">Members</a></li>
         <li><a href="contact.html">Contact</a></li>
       </ul>
     </nav>

--- a/calendar.html
+++ b/calendar.html
@@ -69,12 +69,14 @@
           </li>
 
           <li><a href="leadership.html">Leadership</a></li>
+          <li><a href="members.html">Members</a></li>
           <li><a href="contact.html">Contact</a></li>
         </ul>
       </nav>
       <div class="nav-left">
-        <a href="index.html" aria-label="Home">
+        <a href="index.html" aria-label="Home" class="brand-link">
           <img src="PDULOGO_Trans.png" alt="PDU Logo" class="logo-pdu" />
+          <span class="brand-text">NYU | PDU</span>
         </a>
       </div>
       <button id="burger" class="nav-burger" aria-controls="mobileDrawer" aria-expanded="false" aria-label="Open menu">☰</button>
@@ -125,6 +127,7 @@
         </li>
 
         <li><a href="leadership.html">Leadership</a></li>
+        <li><a href="members.html">Members</a></li>
         <li><a href="contact.html">Contact</a></li>
       </ul>
     </nav>

--- a/contact.html
+++ b/contact.html
@@ -153,14 +153,16 @@
           </li>
 
           <li><a href="leadership.html">Leadership</a></li>
+          <li><a href="members.html">Members</a></li>
           <li><a href="contact.html" aria-current="page">Contact</a></li>
         </ul>
       </nav>
 
       <!-- PDU logo (left on desktop; centered on mobile) -->
       <div class="nav-left">
-        <a href="index.html" aria-label="Home">
+        <a href="index.html" aria-label="Home" class="brand-link">
           <img src="PDULOGO_Trans.png" alt="PDU Logo" class="logo-pdu" />
+          <span class="brand-text">NYU | PDU</span>
         </a>
       </div>
 
@@ -213,6 +215,7 @@
         </li>
 
         <li><a href="leadership.html">Leadership</a></li>
+        <li><a href="members.html">Members</a></li>
         <li><a href="contact.html">Contact</a></li>
       </ul>
     </nav>

--- a/equity.html
+++ b/equity.html
@@ -64,14 +64,16 @@
           </li>
 
           <li><a href="leadership.html">Leadership</a></li>
+          <li><a href="members.html">Members</a></li>
           <li><a href="contact.html">Contact</a></li>
         </ul>
       </nav>
 
       <!-- PDU (centered on mobile) -->
       <div class="nav-left">
-        <a href="index.html" aria-label="Home">
+        <a href="index.html" aria-label="Home" class="brand-link">
           <img src="PDULOGO_Trans.png" alt="PDU Logo" class="logo-pdu" />
+          <span class="brand-text">NYU | PDU</span>
         </a>
       </div>
 
@@ -124,6 +126,7 @@
         </li>
 
         <li><a href="leadership.html">Leadership</a></li>
+        <li><a href="members.html">Members</a></li>
         <li><a href="contact.html">Contact</a></li>
       </ul>
     </nav>

--- a/index.html
+++ b/index.html
@@ -116,13 +116,15 @@
           </li>
 
           <li><a href="leadership.html">Leadership</a></li>
+          <li><a href="members.html">Members</a></li>
           <li><a href="contact.html">Contact</a></li>
         </ul>
       </nav>
 
       <div class="nav-left">
-        <a href="index.html" aria-label="Home">
+        <a href="index.html" aria-label="Home" class="brand-link">
           <img src="PDULOGO_Trans.png" alt="PDU Logo" class="logo-pdu" />
+          <span class="brand-text">NYU | PDU</span>
         </a>
       </div>
 
@@ -174,6 +176,7 @@
         </li>
 
         <li><a href="leadership.html">Leadership</a></li>
+        <li><a href="members.html">Members</a></li>
         <li><a href="contact.html">Contact</a></li>
       </ul>
     </nav>

--- a/join.html
+++ b/join.html
@@ -215,13 +215,15 @@
           </li>
 
           <li><a href="leadership.html">Leadership</a></li>
+          <li><a href="members.html">Members</a></li>
           <li><a href="contact.html">Contact</a></li>
         </ul>
       </nav>
 
       <div class="nav-left">
-        <a href="index.html" aria-label="Home">
+        <a href="index.html" aria-label="Home" class="brand-link">
           <img src="PDULOGO_Trans.png" alt="PDU Logo" class="logo-pdu" />
+          <span class="brand-text">NYU | PDU</span>
         </a>
       </div>
 
@@ -273,6 +275,7 @@
         </li>
 
         <li><a href="leadership.html">Leadership</a></li>
+        <li><a href="members.html">Members</a></li>
         <li><a href="contact.html">Contact</a></li>
       </ul>
     </nav>

--- a/judging.html
+++ b/judging.html
@@ -229,13 +229,15 @@
           </li>
 
           <li><a href="leadership.html">Leadership</a></li>
+          <li><a href="members.html">Members</a></li>
           <li><a href="contact.html">Contact</a></li>
         </ul>
       </nav>
 
       <div class="nav-left">
-        <a href="index.html" aria-label="Home">
+        <a href="index.html" aria-label="Home" class="brand-link">
           <img src="PDULOGO_Trans.png" alt="PDU Logo" class="logo-pdu" />
+          <span class="brand-text">NYU | PDU</span>
         </a>
       </div>
 
@@ -287,6 +289,7 @@
         </li>
 
         <li><a href="leadership.html">Leadership</a></li>
+        <li><a href="members.html">Members</a></li>
         <li><a href="contact.html">Contact</a></li>
       </ul>
     </nav>

--- a/leadership.html
+++ b/leadership.html
@@ -242,14 +242,16 @@
           </li>
 
           <li><a href="leadership.html" aria-current="page">Leadership</a></li>
+          <li><a href="members.html">Members</a></li>
           <li><a href="contact.html">Contact</a></li>
         </ul>
       </nav>
 
       <!-- PDU logo (left on desktop; centered on mobile) -->
       <div class="nav-left">
-        <a href="index.html" aria-label="Home">
+        <a href="index.html" aria-label="Home" class="brand-link">
           <img src="PDULOGO_Trans.png" alt="PDU Logo" class="logo-pdu" />
+          <span class="brand-text">NYU | PDU</span>
         </a>
       </div>
 
@@ -302,6 +304,7 @@
         </li>
 
         <li><a href="leadership.html">Leadership</a></li>
+        <li><a href="members.html">Members</a></li>
         <li><a href="contact.html">Contact</a></li>
       </ul>
     </nav>

--- a/members.html
+++ b/members.html
@@ -150,8 +150,9 @@
       </nav>
 
       <div class="nav-left">
-        <a href="index.html" aria-label="Home">
+        <a href="index.html" aria-label="Home" class="brand-link">
           <img src="PDULOGO_Trans.png" alt="PDU Logo" class="logo-pdu" />
+          <span class="brand-text">NYU | PDU</span>
         </a>
       </div>
 

--- a/practicetools.html
+++ b/practicetools.html
@@ -258,13 +258,15 @@
           </li>
 
           <li><a href="leadership.html">Leadership</a></li>
+          <li><a href="members.html">Members</a></li>
           <li><a href="contact.html">Contact</a></li>
         </ul>
       </nav>
 
       <div class="nav-left">
-        <a href="index.html" aria-label="Home">
+        <a href="index.html" aria-label="Home" class="brand-link">
           <img src="PDULOGO_Trans.png" alt="PDU Logo" class="logo-pdu" />
+          <span class="brand-text">NYU | PDU</span>
         </a>
       </div>
 
@@ -316,6 +318,7 @@
         </li>
 
         <li><a href="leadership.html">Leadership</a></li>
+        <li><a href="members.html">Members</a></li>
         <li><a href="contact.html">Contact</a></li>
       </ul>
     </nav>

--- a/resources.html
+++ b/resources.html
@@ -184,13 +184,15 @@
           </li>
 
           <li><a href="leadership.html">Leadership</a></li>
+          <li><a href="members.html">Members</a></li>
           <li><a href="contact.html">Contact</a></li>
         </ul>
       </nav>
 
       <div class="nav-left">
-        <a href="index.html" aria-label="Home">
+        <a href="index.html" aria-label="Home" class="brand-link">
           <img src="PDULOGO_Trans.png" alt="PDU Logo" class="logo-pdu" />
+          <span class="brand-text">NYU | PDU</span>
         </a>
       </div>
 
@@ -242,6 +244,7 @@
         </li>
 
         <li><a href="leadership.html">Leadership</a></li>
+        <li><a href="members.html">Members</a></li>
         <li><a href="contact.html">Contact</a></li>
       </ul>
     </nav>

--- a/style.css
+++ b/style.css
@@ -79,6 +79,16 @@ nav a:hover{ color:#fff; text-shadow:0 0 8px rgba(199,191,255,.9); }
 .nav-left,.nav-right{ display:flex; align-items:center; }
 .logo-pdu{ height:64px; width:auto; margin-right:1rem; }
 .logo-nyu{ height:28px; width:auto; margin-left:0; }
+.brand-link{ display:flex; align-items:center; text-decoration:none; }
+.brand-text{ display:none; margin-left:.5rem; font-family:'DM Serif Display', serif; font-size:1.5rem; font-weight:700; color:#fff; }
+
+ @media (min-width:961px){
+  .nav-left{ order:0; }
+  .nav-links{ order:1; }
+  .nav-right{ order:2; }
+  .brand-text{ display:inline-block; }
+}
+
 
 /* ================= Desktop primary nav ================= */
 .nav-links{ display:block; }

--- a/tournaments.html
+++ b/tournaments.html
@@ -132,13 +132,15 @@
           </li>
 
           <li><a href="leadership.html">Leadership</a></li>
+          <li><a href="members.html">Members</a></li>
           <li><a href="contact.html">Contact</a></li>
         </ul>
       </nav>
 
       <div class="nav-left">
-        <a href="index.html" aria-label="Home">
+        <a href="index.html" aria-label="Home" class="brand-link">
           <img src="PDULOGO_Trans.png" alt="PDU Logo" class="logo-pdu" />
+          <span class="brand-text">NYU | PDU</span>
         </a>
       </div>
 
@@ -190,6 +192,7 @@
         </li>
 
         <li><a href="leadership.html">Leadership</a></li>
+        <li><a href="members.html">Members</a></li>
         <li><a href="contact.html">Contact</a></li>
       </ul>
     </nav>


### PR DESCRIPTION
## Summary
- Move PDU logo to left and NYU logo to right on desktop navbar; add "NYU | PDU" text beside PDU logo
- Insert Members link in desktop and mobile navigation across site
- Style desktop navbar to reflect new layout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b09fab86f08322b21fdcb431553d1e