### PR TITLE
Add glowing hero divider across site pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -140,6 +140,8 @@
     </div>
   </section>
 
+  <div class="hero-divider" aria-hidden="true"></div>
+
   <!-- Contents Drawer -->
   <aside class="toc-drawer" id="tocDrawer" aria-label="On-page contents">
     <div class="toc-header">

--- a/advanced.html
+++ b/advanced.html
@@ -220,6 +220,7 @@
       </div>
     </div>
   </section>
+  <div class="hero-divider" aria-hidden="true"></div>
 
   <!-- =========================================
        CONTENTS DRAWER

--- a/beginner.html
+++ b/beginner.html
@@ -271,6 +271,8 @@
     </div>
   </section>
 
+  <div class="hero-divider" aria-hidden="true"></div>
+
   <!-- Contents Drawer (preserved) -->
   <aside class="toc-drawer" id="tocDrawer" aria-label="On-page contents">
     <div class="toc-header">

--- a/calendar.html
+++ b/calendar.html
@@ -140,6 +140,8 @@
     </div>
   </section>
 
+  <div class="hero-divider" aria-hidden="true"></div>
+
   <main class="main-content">
     <section class="glass-card reveal cal-wrapper">
       <h3 class="about-header">Subscribe</h3>

--- a/contact.html
+++ b/contact.html
@@ -229,6 +229,8 @@
     </div>
   </section>
 
+  <div class="hero-divider" aria-hidden="true"></div>
+
   <main class="page-wrap">
     <!-- ===== Quick Contacts (direct people) ===== -->
     <section class="glass-card reveal" aria-labelledby="quick-contacts">

--- a/equity.html
+++ b/equity.html
@@ -140,6 +140,8 @@
     </div>
   </section>
 
+  <div class="hero-divider" aria-hidden="true"></div>
+
   <!-- Contents Drawer -->
   <aside class="toc-drawer" id="tocDrawer" aria-label="On-page contents">
     <div class="toc-header">

--- a/join.html
+++ b/join.html
@@ -301,6 +301,8 @@
     </div>
   </section>
 
+  <div class="hero-divider" aria-hidden="true"></div>
+
   <!-- Countdown (NY time) -->
   <div class="join-countdown" id="nextCountdown" aria-live="polite">Calculating next meeting…</div>
 

--- a/judging.html
+++ b/judging.html
@@ -309,6 +309,8 @@
     </div>
   </section>
 
+  <div class="hero-divider" aria-hidden="true"></div>
+
   <!-- ============== CONTENTS DRAWER ============== -->
   <aside class="toc-drawer" id="tocDrawer" aria-label="On-page contents">
     <div class="toc-header">

--- a/leadership.html
+++ b/leadership.html
@@ -58,30 +58,7 @@
     }
     .page-subtitle{ opacity:.9; margin:0; font-size:1.05rem; }
 
-    /* ===== PRESERVED GLOWING BAR (unchanged) ===== */
-    .hero-divider{
-      width:100vw; height:16px;
-      position:relative; left:50%; transform:translateX(-50%);
-      background: linear-gradient(90deg, rgba(255,255,255,.25), rgba(124,58,237,.35), rgba(255,255,255,.25));
-      border-top:1px solid rgba(255,255,255,.25);
-      border-bottom:1px solid rgba(255,255,255,.15);
-      box-shadow: 0 0 18px rgba(199,191,255,.45), 0 0 34px rgba(124,58,237,.35);
-      overflow:hidden;
-      animation: pulseGlow 4.5s ease-in-out infinite alternate;
-    }
-    .hero-divider::before{
-      content:"";
-      position:absolute; inset:0;
-      background:linear-gradient(120deg, transparent 0%, rgba(255,255,255,.45) 35%, transparent 70%);
-      transform:translateX(-100%);
-      animation: sheen 5.8s linear infinite;
-      mix-blend-mode: screen;
-    }
-    @keyframes pulseGlow{
-      0% { box-shadow: 0 0 16px rgba(255,255,255,.35), 0 0 28px rgba(124,58,237,.28); }
-      100% { box-shadow: 0 0 22px rgba(199,191,255,.6), 0 0 42px rgba(124,58,237,.5); }
-    }
-    @keyframes sheen{ 0% { transform:translateX(-100%); } 100% { transform:translateX(100%); } }
+    /* Glowing bar styles moved to global stylesheet */
 
     /* ===== Main wrapper ===== */
     .container{ max-width: 1100px; margin: 0 auto; padding: 1.25rem; }

--- a/members.html
+++ b/members.html
@@ -212,6 +212,8 @@
     </div>
   </section>
 
+  <div class="hero-divider" aria-hidden="true"></div>
+
   <!-- ===== TOP STAT STRIP ===== -->
   <section class="section">
     <div class="dash-container dash-grid">

--- a/practicetools.html
+++ b/practicetools.html
@@ -335,6 +335,8 @@
     </div>
   </section>
 
+  <div class="hero-divider" aria-hidden="true"></div>
+
   <!-- ====================== CONTENTS DRAWER ====================== -->
   <aside class="toc-drawer" id="tocDrawer" aria-label="On-page contents">
     <div class="toc-header">

--- a/resources.html
+++ b/resources.html
@@ -263,6 +263,8 @@
     </div>
   </section>
 
+  <div class="hero-divider" aria-hidden="true"></div>
+
   <!-- ====================== CONTENTS DRAWER ====================== -->
   <aside class="toc-drawer" id="tocDrawer" aria-label="On-page contents">
     <div class="toc-header">

--- a/style.css
+++ b/style.css
@@ -201,6 +201,33 @@ nav a:hover{ color:#fff; text-shadow:0 0 8px rgba(199,191,255,.9); }
 }
 .page-subtitle{ margin-top:.5rem; font-size:1.1rem; opacity:.9; text-align:center; }
 
+/* Glowing divider separating hero from body */
+.hero-divider{
+  width:100vw; height:16px;
+  position:relative; left:50%; transform:translateX(-50%);
+  background:linear-gradient(90deg, rgba(255,255,255,.25), rgba(124,58,237,.35), rgba(255,255,255,.25));
+  border-top:1px solid rgba(255,255,255,.25);
+  border-bottom:1px solid rgba(255,255,255,.15);
+  box-shadow:0 0 18px rgba(199,191,255,.45), 0 0 34px rgba(124,58,237,.35);
+  overflow:hidden;
+  animation:pulseGlow 4.5s ease-in-out infinite alternate;
+}
+.hero-divider::before{
+  content:""; position:absolute; inset:0;
+  background:linear-gradient(120deg, transparent 0%, rgba(255,255,255,.45) 35%, transparent 70%);
+  transform:translateX(-100%);
+  animation:sheen 5.8s linear infinite;
+  mix-blend-mode:screen;
+}
+@keyframes pulseGlow{
+  0%{ box-shadow:0 0 16px rgba(255,255,255,.35), 0 0 28px rgba(124,58,237,.28); }
+  100%{ box-shadow:0 0 22px rgba(199,191,255,.6), 0 0 42px rgba(124,58,237,.5); }
+}
+@keyframes sheen{
+  0%{ transform:translateX(-100%); }
+  100%{ transform:translateX(100%); }
+}
+
 /* ====== Home hero overlay ====== */
 .hero-home{ position:relative; }
 .hero-content{

--- a/tournaments.html
+++ b/tournaments.html
@@ -211,6 +211,8 @@
     </div>
   </section>
 
+  <div class="hero-divider" aria-hidden="true"></div>
+
   <!-- Contents Drawer (IDENTICAL pattern to About) -->
   <aside class="toc-drawer" id="tocDrawer" aria-label="On-page contents">
     <div class="toc-header">


### PR DESCRIPTION
## Summary
- add global CSS for animated glowing hero divider
- insert hero divider markup after hero sections on all pages except the home page
- clean up leadership page by moving divider styles to shared stylesheet

## Testing
- `npx -y htmlhint '*.html'` *(fails: Special characters must be escaped, Doctype must be declared before any non-comment content)*

------
https://chatgpt.com/codex/tasks/task_e_68b0bfa8c5448322900cf9ace39c1485