### PR TITLE
Refine leadership page layout and modal

### DIFF
--- a/leadership.html
+++ b/leadership.html
@@ -50,11 +50,12 @@
       margin: 0 0 .25rem;
     }
     .page-subtitle{ opacity:.9; margin:0; font-size:1.05rem; }
+    #leadersHero{ flex-direction:column; text-align:center; }
 
     /* Glowing bar styles moved to global stylesheet */
 
     /* ===== Main wrapper ===== */
-    .container{ max-width: 1100px; margin: 0 auto; padding: 1.25rem; }
+    .page-container{ max-width: 1100px; margin: 0 auto; padding: 1.25rem; }
 
     /* ===== Fine print ===== */
     .fine-print{
@@ -118,12 +119,10 @@
     .leader-media img{ position:absolute; inset:0; width:100%; height:100%; object-fit:cover; object-position:50% 20%; display:block; }
 
     /* Info band */
-
-    .leader-info{ padding: .45rem 1rem 1.1rem; text-align:center; color:#fff; }
-    .leader-info{ padding: .7rem 1rem .9rem; text-align:center; color:#fff; }
+    .leader-info{ padding: .4rem 1rem .55rem; text-align:center; color:#fff; }
     .leader-name{ font-family:"DM Serif Display", serif; font-size: clamp(1.35rem, 1.1rem + .8vw, 1.85rem); margin:0; letter-spacing:.2px; }
     .leader-sep{
-      width:72%; height:2px; margin:.4rem auto .45rem;
+      width:72%; height:2px; margin:.3rem auto .35rem;
       background: linear-gradient(90deg, rgba(255,255,255,.4), var(--pdu-purple), rgba(255,255,255,.4));
       box-shadow: 0 0 10px rgba(199,191,255,.4);
       border-radius:999px;
@@ -131,13 +130,13 @@
     .leader-title{ font-weight:400; letter-spacing:.3px; opacity:.95; margin:0; }
 
     /* ===== Modal (full-screen) ===== */
-    .modal{ position:fixed; inset:0; z-index:1000; display:none; }
-    .modal.open{ display:block; }
+    .modal{ position:fixed; inset:0; z-index:1000; display:none; align-items:center; justify-content:center; }
+    .modal.open{ display:flex; }
     .modal-scrim{
       position:absolute; inset:0; background: rgba(8,8,16,.75); backdrop-filter: blur(6px);
     }
     .modal-panel{
-      position:relative; z-index:1001; max-width: 980px; margin: calc(min(8vh,80px) + 40px) auto; padding: 0;
+      position:relative; z-index:1001; max-width: 980px; margin: 0 1rem; padding: 0;
       background: var(--glass-bg); border:1px solid var(--glass-border); border-radius: 20px;
       box-shadow: 0 20px 60px rgba(0,0,0,.45);
       overflow:hidden; display:flex; flex-direction:column;
@@ -312,14 +311,14 @@
   <!-- Hero -->
   <section class="hero-section hero-compact" id="leadersHero">
     <h1 class="page-title">Leadership</h1>
-    <p class="page-subtitle">Parliamentary Debate Union Executive Board</p>
+    <p class="page-subtitle">NYU Parliamentary Debate Union Executive Board</p>
   </section>
 
   <!-- Glowing divider (kept) -->
   <div class="hero-divider" aria-hidden="true"></div>
 
   <!-- Main -->
-  <main class="container">
+  <main class="page-container">
     <!-- Fine print (requested) -->
     <p class="fine-print">Click any card to learn more.</p>
 
@@ -363,7 +362,7 @@
       <button type="button" class="leader-card fade-in"
               aria-haspopup="dialog"
               data-name="Marcel Cato"
-              data-role="Director of Operations"
+              data-role="Operations"
               data-img="your-photo.jpg"
               data-email="placeholder@nyu.edu"
               data-bio="Travel, logistics, rosters, and TIDs—your point of contact for sign-ups, itineraries, and attendance.">
@@ -371,7 +370,7 @@
         <div class="leader-info">
           <h3 class="leader-name">Marcel Cato</h3>
           <div class="leader-sep" aria-hidden="true"></div>
-          <p class="leader-title">Director of Operations</p>
+          <p class="leader-title">Operations</p>
         </div>
       </button>
 


### PR DESCRIPTION
## Summary
- Reduce leadership nav height by removing extra container padding
- Center hero heading and subtitle and update copy
- Tighten leader card text spacing and center profile modal
- Update Marcel Cato role to Operations

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0ce6a2c608322b624fddfa523561a