### PR TITLE
Remove fixed height from leadership info

### DIFF
--- a/style.css
+++ b/style.css
@@ -351,9 +351,7 @@ section[id] .about-header, section[id] h3, section[id] h4{ scroll-margin-top:96p
 }
 .leader-card:hover{ transform:translateY(-5px); }
 .leader-photo{ width:100%; height:70%; object-fit:cover; display:block; }
-.leader-info{ height:30%; padding:1rem; display:flex; flex-direction:column; justify-content:center; align-items:center; text-align:center; }
-.leader-info h3{ margin-bottom:.25rem; font-size:1.1rem; font-weight:700; }
-.leader-info p{ margin:0; font-size:.95rem; opacity:.85; }
+/* Legacy .leader-info styles removed to allow content to size naturally */
 .leader-popup{
   position:absolute; top:0; left:0; width:100%; height:100%;
   background:rgba(18,18,30,.9); backdrop-filter:blur(10px);


### PR DESCRIPTION
## Summary
- remove legacy `.leader-info` rules that set a fixed height

## Testing
- `node - <<'NODE'
const puppeteer = require('puppeteer');
(async () => {
  const browser = await puppeteer.launch({args:['--no-sandbox', '--disable-setuid-sandbox']});
  const page = await browser.newPage();
  await page.goto('file:///workspace/nyupdu.github.io/leadership.html');
  await page.waitForSelector('.leader-info');
  const results = await page.$$eval('.leader-info', infos => infos.map(info => ({
    nameHeight: info.querySelector('.leader-name')?.clientHeight || 0,
    sepHeight: info.querySelector('.leader-sep')?.clientHeight || 0,
    titleHeight: info.querySelector('.leader-title')?.clientHeight || 0,
    overflow: info.clientHeight < info.scrollHeight
  })));
  console.log(JSON.stringify(results));
  await browser.close();
})();
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68b0d59ec5c483228d4f1640a7088cee