### PR TITLE
Reorder navigation and highlight Join Us link

### DIFF
--- a/about.html
+++ b/about.html
@@ -28,46 +28,47 @@
       </div>
 
       <!-- Desktop links center -->
-            <nav class="nav-links" aria-label="Primary">
-        <ul class="menu-root">
-          <li><a href="index.html">Home</a></li>
+            
+<nav class="nav-links" aria-label="Primary">
+  <ul class="menu-root">
+    <li><a href="index.html">Home</a></li>
+    <li><a href="members.html">Members</a></li>
 
-          <li class="has-submenu">
-            <a href="about.html" class="top-link" aria-haspopup="true" aria-expanded="false" aria-current="page">About</a>
-            <ul class="submenu" role="menu" aria-label="About submenu">
-              <li role="none"><a role="menuitem" href="about.html#who-we-are">Who We Are</a></li>
-              <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
-              <li role="none"><a role="menuitem" href="about.html#meetings">Meetings & Attendance</a></li>
-              <li role="none"><a role="menuitem" href="equity.html">Equity Policy</a></li>
-              <li role="none"><a role="menuitem" href="why-pdu.html">Why PDU</a></li>
-            </ul>
-          </li>
+    <li class="has-submenu">
+      <a href="about.html" class="top-link" aria-current="page" aria-haspopup="true" aria-expanded="false">About</a>
+      <ul class="submenu" role="menu" aria-label="About submenu">
+        <li role="none"><a role="menuitem" href="about.html#who-we-are">Who We Are</a></li>
+        <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
+        <li role="none"><a role="menuitem" href="about.html#meetings">Meetings & Attendance</a></li>
+        <li role="none"><a role="menuitem" href="equity.html">Equity Policy</a></li>
+        <li role="none"><a role="menuitem" href="why-pdu.html">Why PDU</a></li>
+      </ul>
+    </li>
 
-          <li class="has-submenu">
-            <a href="tournaments.html" class="top-link" aria-haspopup="true" aria-expanded="false">Tournaments</a>
-            <ul class="submenu" role="menu" aria-label="Tournaments submenu">
-              <li role="none"><a role="menuitem" href="tournaments.html#featured">Next Tournament</a></li>
-              <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
-            </ul>
-          </li>
+    <li class="has-submenu">
+      <a href="tournaments.html" class="top-link" aria-haspopup="true" aria-expanded="false">Tournaments</a>
+      <ul class="submenu" role="menu" aria-label="Tournaments submenu">
+        <li role="none"><a role="menuitem" href="tournaments.html#featured">Next Tournament</a></li>
+        <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
+      </ul>
+    </li>
 
-          <li class="has-submenu">
-            <a href="join.html" class="top-link" aria-haspopup="true" aria-expanded="false">Join Us</a>
-            <ul class="submenu" role="menu" aria-label="Join Us submenu">
-              <li role="none"><a role="menuitem" href="join.html#mailing">Mailing List</a></li>
-              <li role="none"><a role="menuitem" href="join.html#meetings">Meetings</a></li>
-              <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
-              <li role="none"><a role="menuitem" href="practicetools.html">Practice Tools</a></li>
-              <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
-              <li role="none"><a role="menuitem" href="resources.html">Resources Library</a></li>
-            </ul>
-          </li>
+    <li class="has-submenu">
+      <a href="join.html" class="top-link join-link" aria-haspopup="true" aria-expanded="false">Join Us</a>
+      <ul class="submenu" role="menu" aria-label="Join Us submenu">
+        <li role="none"><a role="menuitem" href="join.html#mailing">Mailing List</a></li>
+        <li role="none"><a role="menuitem" href="join.html#meetings">Meetings</a></li>
+        <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
+        <li role="none"><a role="menuitem" href="practicetools.html">Practice Tools</a></li>
+        <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
+        <li role="none"><a role="menuitem" href="resources.html">Resources Library</a></li>
+      </ul>
+    </li>
 
-          <li><a href="leadership.html">Leadership</a></li>
-          <li><a href="members.html">Members</a></li>
-          <li><a href="contact.html">Contact</a></li>
-        </ul>
-      </nav>
+    <li><a href="leadership.html">Leadership</a></li>
+    <li><a href="contact.html">Contact</a></li>
+  </ul>
+</nav>
 
       <!-- PDU logo (left on desktop; centered on mobile) -->
       <div class="nav-left">
@@ -89,47 +90,48 @@
       <span>Menu</span>
       <button id="drawerClose" class="drawer-close" aria-label="Close menu">×</button>
     </div>
-        <nav class="drawer-nav" aria-label="Mobile">
-      <ul class="drawer-list">
-        <li><a href="index.html">Home</a></li>
+        
+<nav class="drawer-nav" aria-label="Mobile">
+  <ul class="drawer-list">
+    <li><a href="index.html">Home</a></li>
+    <li><a href="members.html">Members</a></li>
 
-        <li class="drawer-group">
-          <button class="drawer-toggle" aria-expanded="false">About</button>
-          <ul class="drawer-submenu">
-            <li><a href="about.html#who-we-are">Who We Are</a></li>
-            <li><a href="beginner.html">Beginners Guide</a></li>
-            <li><a href="about.html#meetings">Meetings & Attendance</a></li>
-            <li><a href="equity.html">Equity Policy</a></li>
-            <li><a href="why-pdu.html">Why PDU</a></li>
-          </ul>
-        </li>
-
-        <li class="drawer-group">
-          <button class="drawer-toggle" aria-expanded="false">Tournaments</button>
-          <ul class="drawer-submenu">
-            <li><a href="tournaments.html#featured">Next Tournament</a></li>
-            <li><a href="tournaments.html">Upcoming</a></li>
-            <li><a href="calendar.html">Calendar</a></li>
-          </ul>
-        </li>
-
-        <li class="drawer-group">
-          <button class="drawer-toggle" aria-expanded="false">Join Us</button>
-          <ul class="drawer-submenu">
-            <li><a href="join.html#mailing">Mailing List</a></li>
-            <li><a href="join.html#meetings">Meetings</a></li>
-            <li><a href="beginner.html">Beginners Guide</a></li>
-            <li><a href="practicetools.html">Practice Tools</a></li>
-            <li><a href="calendar.html">Calendar</a></li>
-            <li><a href="resources.html">Resources Library</a></li>
-          </ul>
-        </li>
-
-        <li><a href="leadership.html">Leadership</a></li>
-        <li><a href="members.html">Members</a></li>
-        <li><a href="contact.html">Contact</a></li>
+    <li class="drawer-group">
+      <button class="drawer-toggle" aria-expanded="false" aria-current="page">About</button>
+      <ul class="drawer-submenu">
+        <li><a href="about.html#who-we-are">Who We Are</a></li>
+        <li><a href="beginner.html">Beginners Guide</a></li>
+        <li><a href="about.html#meetings">Meetings & Attendance</a></li>
+        <li><a href="equity.html">Equity Policy</a></li>
+        <li><a href="why-pdu.html">Why PDU</a></li>
       </ul>
-    </nav>
+    </li>
+
+    <li class="drawer-group">
+      <button class="drawer-toggle" aria-expanded="false">Tournaments</button>
+      <ul class="drawer-submenu">
+        <li><a href="tournaments.html#featured">Next Tournament</a></li>
+        <li><a href="tournaments.html">Upcoming</a></li>
+        <li><a href="calendar.html">Calendar</a></li>
+      </ul>
+    </li>
+
+    <li class="drawer-group">
+      <button class="drawer-toggle join-link" aria-expanded="false">Join Us</button>
+      <ul class="drawer-submenu">
+        <li><a href="join.html#mailing">Mailing List</a></li>
+        <li><a href="join.html#meetings">Meetings</a></li>
+        <li><a href="beginner.html">Beginners Guide</a></li>
+        <li><a href="practicetools.html">Practice Tools</a></li>
+        <li><a href="calendar.html">Calendar</a></li>
+        <li><a href="resources.html">Resources Library</a></li>
+      </ul>
+    </li>
+
+    <li><a href="leadership.html">Leadership</a></li>
+    <li><a href="contact.html">Contact</a></li>
+  </ul>
+</nav>
   </aside>
 
   <!-- Hero -->

--- a/advanced.html
+++ b/advanced.html
@@ -116,36 +116,47 @@
         <img src="NYU_Short_RGB_White.png" alt="NYU Logo" class="logo-nyu" />
       </div>
 
-      <nav class="nav-links" aria-label="Primary">
-        <ul class="menu-root">
-          <li><a href="index.html">Home</a></li>
+      
+<nav class="nav-links" aria-label="Primary">
+  <ul class="menu-root">
+    <li><a href="index.html">Home</a></li>
+    <li><a href="members.html">Members</a></li>
 
-          <li class="has-submenu">
-            <a href="about.html" class="top-link" aria-haspopup="true" aria-expanded="false">About</a>
-            <ul class="submenu" role="menu" aria-label="About submenu">
-              <li role="none"><a role="menuitem" href="about.html#who-we-are">Who We Are</a></li>
-              <li role="none"><a role="menuitem" href="about.html#apda">What is APDA?</a></li>
-              <li role="none"><a role="menuitem" href="about.html#meetings">Meetings & Attendance</a></li>
-              <li role="none"><a role="menuitem" href="equity.html">Equity</a></li>
-              <li role="none"><a role="menuitem" href="why-pdu.html">Why PDU</a></li>
-            </ul>
-          </li>
+    <li class="has-submenu">
+      <a href="about.html" class="top-link" aria-haspopup="true" aria-expanded="false">About</a>
+      <ul class="submenu" role="menu" aria-label="About submenu">
+        <li role="none"><a role="menuitem" href="about.html#who-we-are">Who We Are</a></li>
+        <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
+        <li role="none"><a role="menuitem" href="about.html#meetings">Meetings & Attendance</a></li>
+        <li role="none"><a role="menuitem" href="equity.html">Equity Policy</a></li>
+        <li role="none"><a role="menuitem" href="why-pdu.html">Why PDU</a></li>
+      </ul>
+    </li>
 
-          <li><a href="tournaments.html">Tournaments</a></li>
+    <li class="has-submenu">
+      <a href="tournaments.html" class="top-link" aria-haspopup="true" aria-expanded="false">Tournaments</a>
+      <ul class="submenu" role="menu" aria-label="Tournaments submenu">
+        <li role="none"><a role="menuitem" href="tournaments.html#featured">Next Tournament</a></li>
+        <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
+      </ul>
+    </li>
 
-          <li class="has-submenu">
-            <a href="join.html" class="top-link" aria-haspopup="true" aria-expanded="false">Join Us</a>
-            <ul class="submenu" role="menu" aria-label="Join Us submenu">
-              <li role="none"><a role="menuitem" href="join.html#mailing">Mailing List</a></li>
-              <li role="none"><a role="menuitem" href="join.html#beginner-cta">Beginners</a></li>
-              <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
-            </ul>
-          </li>
+    <li class="has-submenu">
+      <a href="join.html" class="top-link join-link" aria-haspopup="true" aria-expanded="false">Join Us</a>
+      <ul class="submenu" role="menu" aria-label="Join Us submenu">
+        <li role="none"><a role="menuitem" href="join.html#mailing">Mailing List</a></li>
+        <li role="none"><a role="menuitem" href="join.html#meetings">Meetings</a></li>
+        <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
+        <li role="none"><a role="menuitem" href="practicetools.html">Practice Tools</a></li>
+        <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
+        <li role="none"><a role="menuitem" href="resources.html">Resources Library</a></li>
+      </ul>
+    </li>
 
-          <li><a href="leadership.html">Leadership</a></li>
-          <li><a href="contact.html">Contact</a></li>
-        </ul>
-      </nav>
+    <li><a href="leadership.html">Leadership</a></li>
+    <li><a href="contact.html">Contact</a></li>
+  </ul>
+</nav>
 
       <div class="nav-left">
         <a href="index.html" aria-label="Home">
@@ -166,36 +177,48 @@
       <span>Menu</span>
       <button id="drawerClose" class="drawer-close" aria-label="Close menu">×</button>
     </div>
-    <nav class="drawer-nav" aria-label="Mobile">
-      <ul class="drawer-list">
-        <li><a href="index.html">Home</a></li>
+    
+<nav class="drawer-nav" aria-label="Mobile">
+  <ul class="drawer-list">
+    <li><a href="index.html">Home</a></li>
+    <li><a href="members.html">Members</a></li>
 
-        <li class="drawer-group">
-          <button class="drawer-toggle" aria-expanded="false">About</button>
-          <ul class="drawer-submenu">
-            <li><a href="about.html#who-we-are">Who We Are</a></li>
-            <li><a href="about.html#apda">What is APDA?</a></li>
-            <li><a href="about.html#meetings">Meetings & Attendance</a></li>
-            <li><a href="equity.html">Equity</a></li>
-            <li><a href="why-pdu.html">Why PDU</a></li>
-          </ul>
-        </li>
-
-        <li><a href="tournaments.html">Tournaments</a></li>
-
-        <li class="drawer-group">
-          <button class="drawer-toggle" aria-expanded="false">Join Us</button>
-          <ul class="drawer-submenu">
-            <li><a href="join.html#mailing">Mailing List</a></li>
-            <li><a href="join.html#beginner-cta">Beginners</a></li>
-            <li><a href="calendar.html">Calendar</a></li>
-          </ul>
-        </li>
-
-        <li><a href="leadership.html">Leadership</a></li>
-        <li><a href="contact.html">Contact</a></li>
+    <li class="drawer-group">
+      <button class="drawer-toggle" aria-expanded="false">About</button>
+      <ul class="drawer-submenu">
+        <li><a href="about.html#who-we-are">Who We Are</a></li>
+        <li><a href="beginner.html">Beginners Guide</a></li>
+        <li><a href="about.html#meetings">Meetings & Attendance</a></li>
+        <li><a href="equity.html">Equity Policy</a></li>
+        <li><a href="why-pdu.html">Why PDU</a></li>
       </ul>
-    </nav>
+    </li>
+
+    <li class="drawer-group">
+      <button class="drawer-toggle" aria-expanded="false">Tournaments</button>
+      <ul class="drawer-submenu">
+        <li><a href="tournaments.html#featured">Next Tournament</a></li>
+        <li><a href="tournaments.html">Upcoming</a></li>
+        <li><a href="calendar.html">Calendar</a></li>
+      </ul>
+    </li>
+
+    <li class="drawer-group">
+      <button class="drawer-toggle join-link" aria-expanded="false">Join Us</button>
+      <ul class="drawer-submenu">
+        <li><a href="join.html#mailing">Mailing List</a></li>
+        <li><a href="join.html#meetings">Meetings</a></li>
+        <li><a href="beginner.html">Beginners Guide</a></li>
+        <li><a href="practicetools.html">Practice Tools</a></li>
+        <li><a href="calendar.html">Calendar</a></li>
+        <li><a href="resources.html">Resources Library</a></li>
+      </ul>
+    </li>
+
+    <li><a href="leadership.html">Leadership</a></li>
+    <li><a href="contact.html">Contact</a></li>
+  </ul>
+</nav>
   </aside>
 
   <!-- =========================================
@@ -510,7 +533,7 @@
           <h4>MG</h4>
           <ul class="list">
             <li>Re-center the <b>heart</b> of case; rebuild with warrant density.</li>
-            <li>One deep new insight > many thin re-tags.</li>
+            <li>One deep new insight &gt; many thin re-tags.</li>
             <li>Set up PMR: announce collapse and lens.</li>
           </ul>
           <p class="small"><b>Traps:</b> chasing every LO tag; re-tagging without warrants.</p>

--- a/beginner.html
+++ b/beginner.html
@@ -157,46 +157,47 @@
         <img src="NYU_Short_RGB_White.png" alt="NYU Logo" class="logo-nyu" />
       </div>
 
-            <nav class="nav-links" aria-label="Primary">
-        <ul class="menu-root">
-          <li><a href="index.html">Home</a></li>
+            
+<nav class="nav-links" aria-label="Primary">
+  <ul class="menu-root">
+    <li><a href="index.html">Home</a></li>
+    <li><a href="members.html">Members</a></li>
 
-          <li class="has-submenu">
-            <a href="about.html" class="top-link" aria-haspopup="true" aria-expanded="false">About</a>
-            <ul class="submenu" role="menu" aria-label="About submenu">
-              <li role="none"><a role="menuitem" href="about.html#who-we-are">Who We Are</a></li>
-              <li role="none"><a role="menuitem" href="beginner.html" aria-current="page">Beginners Guide</a></li>
-              <li role="none"><a role="menuitem" href="about.html#meetings">Meetings & Attendance</a></li>
-              <li role="none"><a role="menuitem" href="equity.html">Equity Policy</a></li>
-              <li role="none"><a role="menuitem" href="why-pdu.html">Why PDU</a></li>
-            </ul>
-          </li>
+    <li class="has-submenu">
+      <a href="about.html" class="top-link" aria-haspopup="true" aria-expanded="false">About</a>
+      <ul class="submenu" role="menu" aria-label="About submenu">
+        <li role="none"><a role="menuitem" href="about.html#who-we-are">Who We Are</a></li>
+        <li role="none"><a role="menuitem" href="beginner.html" aria-current="page">Beginners Guide</a></li>
+        <li role="none"><a role="menuitem" href="about.html#meetings">Meetings & Attendance</a></li>
+        <li role="none"><a role="menuitem" href="equity.html">Equity Policy</a></li>
+        <li role="none"><a role="menuitem" href="why-pdu.html">Why PDU</a></li>
+      </ul>
+    </li>
 
-          <li class="has-submenu">
-            <a href="tournaments.html" class="top-link" aria-haspopup="true" aria-expanded="false">Tournaments</a>
-            <ul class="submenu" role="menu" aria-label="Tournaments submenu">
-              <li role="none"><a role="menuitem" href="tournaments.html#featured">Next Tournament</a></li>
-              <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
-            </ul>
-          </li>
+    <li class="has-submenu">
+      <a href="tournaments.html" class="top-link" aria-haspopup="true" aria-expanded="false">Tournaments</a>
+      <ul class="submenu" role="menu" aria-label="Tournaments submenu">
+        <li role="none"><a role="menuitem" href="tournaments.html#featured">Next Tournament</a></li>
+        <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
+      </ul>
+    </li>
 
-          <li class="has-submenu">
-            <a href="join.html" class="top-link" aria-haspopup="true" aria-expanded="false">Join Us</a>
-            <ul class="submenu" role="menu" aria-label="Join Us submenu">
-              <li role="none"><a role="menuitem" href="join.html#mailing">Mailing List</a></li>
-              <li role="none"><a role="menuitem" href="join.html#meetings">Meetings</a></li>
-              <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
-              <li role="none"><a role="menuitem" href="practicetools.html">Practice Tools</a></li>
-              <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
-              <li role="none"><a role="menuitem" href="resources.html">Resources Library</a></li>
-            </ul>
-          </li>
+    <li class="has-submenu">
+      <a href="join.html" class="top-link join-link" aria-haspopup="true" aria-expanded="false">Join Us</a>
+      <ul class="submenu" role="menu" aria-label="Join Us submenu">
+        <li role="none"><a role="menuitem" href="join.html#mailing">Mailing List</a></li>
+        <li role="none"><a role="menuitem" href="join.html#meetings">Meetings</a></li>
+        <li role="none"><a role="menuitem" href="beginner.html" aria-current="page">Beginners Guide</a></li>
+        <li role="none"><a role="menuitem" href="practicetools.html">Practice Tools</a></li>
+        <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
+        <li role="none"><a role="menuitem" href="resources.html">Resources Library</a></li>
+      </ul>
+    </li>
 
-          <li><a href="leadership.html">Leadership</a></li>
-          <li><a href="members.html">Members</a></li>
-          <li><a href="contact.html">Contact</a></li>
-        </ul>
-      </nav>
+    <li><a href="leadership.html">Leadership</a></li>
+    <li><a href="contact.html">Contact</a></li>
+  </ul>
+</nav>
 
       <div class="nav-left">
         <a href="index.html" aria-label="Home" class="brand-link">
@@ -216,47 +217,48 @@
       <span>Menu</span>
       <button id="drawerClose" class="drawer-close" aria-label="Close menu">×</button>
     </div>
-        <nav class="drawer-nav" aria-label="Mobile">
-      <ul class="drawer-list">
-        <li><a href="index.html">Home</a></li>
+        
+<nav class="drawer-nav" aria-label="Mobile">
+  <ul class="drawer-list">
+    <li><a href="index.html">Home</a></li>
+    <li><a href="members.html">Members</a></li>
 
-        <li class="drawer-group">
-          <button class="drawer-toggle" aria-expanded="false">About</button>
-          <ul class="drawer-submenu">
-            <li><a href="about.html#who-we-are">Who We Are</a></li>
-            <li><a href="beginner.html">Beginners Guide</a></li>
-            <li><a href="about.html#meetings">Meetings & Attendance</a></li>
-            <li><a href="equity.html">Equity Policy</a></li>
-            <li><a href="why-pdu.html">Why PDU</a></li>
-          </ul>
-        </li>
-
-        <li class="drawer-group">
-          <button class="drawer-toggle" aria-expanded="false">Tournaments</button>
-          <ul class="drawer-submenu">
-            <li><a href="tournaments.html#featured">Next Tournament</a></li>
-            <li><a href="tournaments.html">Upcoming</a></li>
-            <li><a href="calendar.html">Calendar</a></li>
-          </ul>
-        </li>
-
-        <li class="drawer-group">
-          <button class="drawer-toggle" aria-expanded="false">Join Us</button>
-          <ul class="drawer-submenu">
-            <li><a href="join.html#mailing">Mailing List</a></li>
-            <li><a href="join.html#meetings">Meetings</a></li>
-            <li><a href="beginner.html">Beginners Guide</a></li>
-            <li><a href="practicetools.html">Practice Tools</a></li>
-            <li><a href="calendar.html">Calendar</a></li>
-            <li><a href="resources.html">Resources Library</a></li>
-          </ul>
-        </li>
-
-        <li><a href="leadership.html">Leadership</a></li>
-        <li><a href="members.html">Members</a></li>
-        <li><a href="contact.html">Contact</a></li>
+    <li class="drawer-group">
+      <button class="drawer-toggle" aria-expanded="false">About</button>
+      <ul class="drawer-submenu">
+        <li><a href="about.html#who-we-are">Who We Are</a></li>
+        <li><a href="beginner.html" aria-current="page">Beginners Guide</a></li>
+        <li><a href="about.html#meetings">Meetings & Attendance</a></li>
+        <li><a href="equity.html">Equity Policy</a></li>
+        <li><a href="why-pdu.html">Why PDU</a></li>
       </ul>
-    </nav>
+    </li>
+
+    <li class="drawer-group">
+      <button class="drawer-toggle" aria-expanded="false">Tournaments</button>
+      <ul class="drawer-submenu">
+        <li><a href="tournaments.html#featured">Next Tournament</a></li>
+        <li><a href="tournaments.html">Upcoming</a></li>
+        <li><a href="calendar.html">Calendar</a></li>
+      </ul>
+    </li>
+
+    <li class="drawer-group">
+      <button class="drawer-toggle join-link" aria-expanded="false">Join Us</button>
+      <ul class="drawer-submenu">
+        <li><a href="join.html#mailing">Mailing List</a></li>
+        <li><a href="join.html#meetings">Meetings</a></li>
+        <li><a href="beginner.html" aria-current="page">Beginners Guide</a></li>
+        <li><a href="practicetools.html">Practice Tools</a></li>
+        <li><a href="calendar.html">Calendar</a></li>
+        <li><a href="resources.html">Resources Library</a></li>
+      </ul>
+    </li>
+
+    <li><a href="leadership.html">Leadership</a></li>
+    <li><a href="contact.html">Contact</a></li>
+  </ul>
+</nav>
   </aside>
 
   <!-- Hero -->

--- a/calendar.html
+++ b/calendar.html
@@ -33,46 +33,47 @@
       <div class="nav-right" aria-label="NYU logo">
         <img src="NYU_Short_RGB_White.png" alt="NYU Logo" class="logo-nyu" />
       </div>
-            <nav class="nav-links" aria-label="Primary">
-        <ul class="menu-root">
-          <li><a href="index.html">Home</a></li>
+            
+<nav class="nav-links" aria-label="Primary">
+  <ul class="menu-root">
+    <li><a href="index.html">Home</a></li>
+    <li><a href="members.html">Members</a></li>
 
-          <li class="has-submenu">
-            <a href="about.html" class="top-link" aria-haspopup="true" aria-expanded="false">About</a>
-            <ul class="submenu" role="menu" aria-label="About submenu">
-              <li role="none"><a role="menuitem" href="about.html#who-we-are">Who We Are</a></li>
-              <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
-              <li role="none"><a role="menuitem" href="about.html#meetings">Meetings & Attendance</a></li>
-              <li role="none"><a role="menuitem" href="equity.html">Equity Policy</a></li>
-              <li role="none"><a role="menuitem" href="why-pdu.html">Why PDU</a></li>
-            </ul>
-          </li>
+    <li class="has-submenu">
+      <a href="about.html" class="top-link" aria-haspopup="true" aria-expanded="false">About</a>
+      <ul class="submenu" role="menu" aria-label="About submenu">
+        <li role="none"><a role="menuitem" href="about.html#who-we-are">Who We Are</a></li>
+        <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
+        <li role="none"><a role="menuitem" href="about.html#meetings">Meetings & Attendance</a></li>
+        <li role="none"><a role="menuitem" href="equity.html">Equity Policy</a></li>
+        <li role="none"><a role="menuitem" href="why-pdu.html">Why PDU</a></li>
+      </ul>
+    </li>
 
-          <li class="has-submenu">
-            <a href="tournaments.html" class="top-link" aria-haspopup="true" aria-expanded="false">Tournaments</a>
-            <ul class="submenu" role="menu" aria-label="Tournaments submenu">
-              <li role="none"><a role="menuitem" href="tournaments.html#featured">Next Tournament</a></li>
-              <li role="none"><a role="menuitem" href="calendar.html" aria-current="page">Calendar</a></li>
-            </ul>
-          </li>
+    <li class="has-submenu">
+      <a href="tournaments.html" class="top-link" aria-haspopup="true" aria-expanded="false">Tournaments</a>
+      <ul class="submenu" role="menu" aria-label="Tournaments submenu">
+        <li role="none"><a role="menuitem" href="tournaments.html#featured">Next Tournament</a></li>
+        <li role="none"><a role="menuitem" href="calendar.html" aria-current="page">Calendar</a></li>
+      </ul>
+    </li>
 
-          <li class="has-submenu">
-            <a href="join.html" class="top-link" aria-haspopup="true" aria-expanded="false">Join Us</a>
-            <ul class="submenu" role="menu" aria-label="Join Us submenu">
-              <li role="none"><a role="menuitem" href="join.html#mailing">Mailing List</a></li>
-              <li role="none"><a role="menuitem" href="join.html#meetings">Meetings</a></li>
-              <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
-              <li role="none"><a role="menuitem" href="practicetools.html">Practice Tools</a></li>
-              <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
-              <li role="none"><a role="menuitem" href="resources.html">Resources Library</a></li>
-            </ul>
-          </li>
+    <li class="has-submenu">
+      <a href="join.html" class="top-link join-link" aria-haspopup="true" aria-expanded="false">Join Us</a>
+      <ul class="submenu" role="menu" aria-label="Join Us submenu">
+        <li role="none"><a role="menuitem" href="join.html#mailing">Mailing List</a></li>
+        <li role="none"><a role="menuitem" href="join.html#meetings">Meetings</a></li>
+        <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
+        <li role="none"><a role="menuitem" href="practicetools.html">Practice Tools</a></li>
+        <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
+        <li role="none"><a role="menuitem" href="resources.html">Resources Library</a></li>
+      </ul>
+    </li>
 
-          <li><a href="leadership.html">Leadership</a></li>
-          <li><a href="members.html">Members</a></li>
-          <li><a href="contact.html">Contact</a></li>
-        </ul>
-      </nav>
+    <li><a href="leadership.html">Leadership</a></li>
+    <li><a href="contact.html">Contact</a></li>
+  </ul>
+</nav>
       <div class="nav-left">
         <a href="index.html" aria-label="Home" class="brand-link">
           <img src="PDULOGO_Trans.png" alt="PDU Logo" class="logo-pdu" />
@@ -90,47 +91,48 @@
       <span>Menu</span>
       <button id="drawerClose" class="drawer-close" aria-label="Close menu">×</button>
     </div>
-        <nav class="drawer-nav" aria-label="Mobile">
-      <ul class="drawer-list">
-        <li><a href="index.html">Home</a></li>
+        
+<nav class="drawer-nav" aria-label="Mobile">
+  <ul class="drawer-list">
+    <li><a href="index.html">Home</a></li>
+    <li><a href="members.html">Members</a></li>
 
-        <li class="drawer-group">
-          <button class="drawer-toggle" aria-expanded="false">About</button>
-          <ul class="drawer-submenu">
-            <li><a href="about.html#who-we-are">Who We Are</a></li>
-            <li><a href="beginner.html">Beginners Guide</a></li>
-            <li><a href="about.html#meetings">Meetings & Attendance</a></li>
-            <li><a href="equity.html">Equity Policy</a></li>
-            <li><a href="why-pdu.html">Why PDU</a></li>
-          </ul>
-        </li>
-
-        <li class="drawer-group">
-          <button class="drawer-toggle" aria-expanded="false">Tournaments</button>
-          <ul class="drawer-submenu">
-            <li><a href="tournaments.html#featured">Next Tournament</a></li>
-            <li><a href="tournaments.html">Upcoming</a></li>
-            <li><a href="calendar.html">Calendar</a></li>
-          </ul>
-        </li>
-
-        <li class="drawer-group">
-          <button class="drawer-toggle" aria-expanded="false">Join Us</button>
-          <ul class="drawer-submenu">
-            <li><a href="join.html#mailing">Mailing List</a></li>
-            <li><a href="join.html#meetings">Meetings</a></li>
-            <li><a href="beginner.html">Beginners Guide</a></li>
-            <li><a href="practicetools.html">Practice Tools</a></li>
-            <li><a href="calendar.html">Calendar</a></li>
-            <li><a href="resources.html">Resources Library</a></li>
-          </ul>
-        </li>
-
-        <li><a href="leadership.html">Leadership</a></li>
-        <li><a href="members.html">Members</a></li>
-        <li><a href="contact.html">Contact</a></li>
+    <li class="drawer-group">
+      <button class="drawer-toggle" aria-expanded="false">About</button>
+      <ul class="drawer-submenu">
+        <li><a href="about.html#who-we-are">Who We Are</a></li>
+        <li><a href="beginner.html">Beginners Guide</a></li>
+        <li><a href="about.html#meetings">Meetings & Attendance</a></li>
+        <li><a href="equity.html">Equity Policy</a></li>
+        <li><a href="why-pdu.html">Why PDU</a></li>
       </ul>
-    </nav>
+    </li>
+
+    <li class="drawer-group">
+      <button class="drawer-toggle" aria-expanded="false">Tournaments</button>
+      <ul class="drawer-submenu">
+        <li><a href="tournaments.html#featured">Next Tournament</a></li>
+        <li><a href="tournaments.html">Upcoming</a></li>
+        <li><a href="calendar.html" aria-current="page">Calendar</a></li>
+      </ul>
+    </li>
+
+    <li class="drawer-group">
+      <button class="drawer-toggle join-link" aria-expanded="false">Join Us</button>
+      <ul class="drawer-submenu">
+        <li><a href="join.html#mailing">Mailing List</a></li>
+        <li><a href="join.html#meetings">Meetings</a></li>
+        <li><a href="beginner.html">Beginners Guide</a></li>
+        <li><a href="practicetools.html">Practice Tools</a></li>
+        <li><a href="calendar.html">Calendar</a></li>
+        <li><a href="resources.html">Resources Library</a></li>
+      </ul>
+    </li>
+
+    <li><a href="leadership.html">Leadership</a></li>
+    <li><a href="contact.html">Contact</a></li>
+  </ul>
+</nav>
   </aside>
 
   <section class="hero-section hero-compact">

--- a/contact.html
+++ b/contact.html
@@ -117,46 +117,47 @@
       </div>
 
       <!-- Desktop links center -->
-            <nav class="nav-links" aria-label="Primary">
-        <ul class="menu-root">
-          <li><a href="index.html">Home</a></li>
+            
+<nav class="nav-links" aria-label="Primary">
+  <ul class="menu-root">
+    <li><a href="index.html">Home</a></li>
+    <li><a href="members.html">Members</a></li>
 
-          <li class="has-submenu">
-            <a href="about.html" class="top-link" aria-haspopup="true" aria-expanded="false">About</a>
-            <ul class="submenu" role="menu" aria-label="About submenu">
-              <li role="none"><a role="menuitem" href="about.html#who-we-are">Who We Are</a></li>
-              <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
-              <li role="none"><a role="menuitem" href="about.html#meetings">Meetings & Attendance</a></li>
-              <li role="none"><a role="menuitem" href="equity.html">Equity Policy</a></li>
-              <li role="none"><a role="menuitem" href="why-pdu.html">Why PDU</a></li>
-            </ul>
-          </li>
+    <li class="has-submenu">
+      <a href="about.html" class="top-link" aria-haspopup="true" aria-expanded="false">About</a>
+      <ul class="submenu" role="menu" aria-label="About submenu">
+        <li role="none"><a role="menuitem" href="about.html#who-we-are">Who We Are</a></li>
+        <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
+        <li role="none"><a role="menuitem" href="about.html#meetings">Meetings & Attendance</a></li>
+        <li role="none"><a role="menuitem" href="equity.html">Equity Policy</a></li>
+        <li role="none"><a role="menuitem" href="why-pdu.html">Why PDU</a></li>
+      </ul>
+    </li>
 
-          <li class="has-submenu">
-            <a href="tournaments.html" class="top-link" aria-haspopup="true" aria-expanded="false">Tournaments</a>
-            <ul class="submenu" role="menu" aria-label="Tournaments submenu">
-              <li role="none"><a role="menuitem" href="tournaments.html#featured">Next Tournament</a></li>
-              <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
-            </ul>
-          </li>
+    <li class="has-submenu">
+      <a href="tournaments.html" class="top-link" aria-haspopup="true" aria-expanded="false">Tournaments</a>
+      <ul class="submenu" role="menu" aria-label="Tournaments submenu">
+        <li role="none"><a role="menuitem" href="tournaments.html#featured">Next Tournament</a></li>
+        <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
+      </ul>
+    </li>
 
-          <li class="has-submenu">
-            <a href="join.html" class="top-link" aria-haspopup="true" aria-expanded="false">Join Us</a>
-            <ul class="submenu" role="menu" aria-label="Join Us submenu">
-              <li role="none"><a role="menuitem" href="join.html#mailing">Mailing List</a></li>
-              <li role="none"><a role="menuitem" href="join.html#meetings">Meetings</a></li>
-              <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
-              <li role="none"><a role="menuitem" href="practicetools.html">Practice Tools</a></li>
-              <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
-              <li role="none"><a role="menuitem" href="resources.html">Resources Library</a></li>
-            </ul>
-          </li>
+    <li class="has-submenu">
+      <a href="join.html" class="top-link join-link" aria-haspopup="true" aria-expanded="false">Join Us</a>
+      <ul class="submenu" role="menu" aria-label="Join Us submenu">
+        <li role="none"><a role="menuitem" href="join.html#mailing">Mailing List</a></li>
+        <li role="none"><a role="menuitem" href="join.html#meetings">Meetings</a></li>
+        <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
+        <li role="none"><a role="menuitem" href="practicetools.html">Practice Tools</a></li>
+        <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
+        <li role="none"><a role="menuitem" href="resources.html">Resources Library</a></li>
+      </ul>
+    </li>
 
-          <li><a href="leadership.html">Leadership</a></li>
-          <li><a href="members.html">Members</a></li>
-          <li><a href="contact.html" aria-current="page">Contact</a></li>
-        </ul>
-      </nav>
+    <li><a href="leadership.html">Leadership</a></li>
+    <li><a href="contact.html" aria-current="page">Contact</a></li>
+  </ul>
+</nav>
 
       <!-- PDU logo (left on desktop; centered on mobile) -->
       <div class="nav-left">
@@ -178,47 +179,48 @@
       <span>Menu</span>
       <button id="drawerClose" class="drawer-close" aria-label="Close menu">×</button>
     </div>
-        <nav class="drawer-nav" aria-label="Mobile">
-      <ul class="drawer-list">
-        <li><a href="index.html">Home</a></li>
+        
+<nav class="drawer-nav" aria-label="Mobile">
+  <ul class="drawer-list">
+    <li><a href="index.html">Home</a></li>
+    <li><a href="members.html">Members</a></li>
 
-        <li class="drawer-group">
-          <button class="drawer-toggle" aria-expanded="false">About</button>
-          <ul class="drawer-submenu">
-            <li><a href="about.html#who-we-are">Who We Are</a></li>
-            <li><a href="beginner.html">Beginners Guide</a></li>
-            <li><a href="about.html#meetings">Meetings & Attendance</a></li>
-            <li><a href="equity.html">Equity Policy</a></li>
-            <li><a href="why-pdu.html">Why PDU</a></li>
-          </ul>
-        </li>
-
-        <li class="drawer-group">
-          <button class="drawer-toggle" aria-expanded="false">Tournaments</button>
-          <ul class="drawer-submenu">
-            <li><a href="tournaments.html#featured">Next Tournament</a></li>
-            <li><a href="tournaments.html">Upcoming</a></li>
-            <li><a href="calendar.html">Calendar</a></li>
-          </ul>
-        </li>
-
-        <li class="drawer-group">
-          <button class="drawer-toggle" aria-expanded="false">Join Us</button>
-          <ul class="drawer-submenu">
-            <li><a href="join.html#mailing">Mailing List</a></li>
-            <li><a href="join.html#meetings">Meetings</a></li>
-            <li><a href="beginner.html">Beginners Guide</a></li>
-            <li><a href="practicetools.html">Practice Tools</a></li>
-            <li><a href="calendar.html">Calendar</a></li>
-            <li><a href="resources.html">Resources Library</a></li>
-          </ul>
-        </li>
-
-        <li><a href="leadership.html">Leadership</a></li>
-        <li><a href="members.html">Members</a></li>
-        <li><a href="contact.html">Contact</a></li>
+    <li class="drawer-group">
+      <button class="drawer-toggle" aria-expanded="false">About</button>
+      <ul class="drawer-submenu">
+        <li><a href="about.html#who-we-are">Who We Are</a></li>
+        <li><a href="beginner.html">Beginners Guide</a></li>
+        <li><a href="about.html#meetings">Meetings & Attendance</a></li>
+        <li><a href="equity.html">Equity Policy</a></li>
+        <li><a href="why-pdu.html">Why PDU</a></li>
       </ul>
-    </nav>
+    </li>
+
+    <li class="drawer-group">
+      <button class="drawer-toggle" aria-expanded="false">Tournaments</button>
+      <ul class="drawer-submenu">
+        <li><a href="tournaments.html#featured">Next Tournament</a></li>
+        <li><a href="tournaments.html">Upcoming</a></li>
+        <li><a href="calendar.html">Calendar</a></li>
+      </ul>
+    </li>
+
+    <li class="drawer-group">
+      <button class="drawer-toggle join-link" aria-expanded="false">Join Us</button>
+      <ul class="drawer-submenu">
+        <li><a href="join.html#mailing">Mailing List</a></li>
+        <li><a href="join.html#meetings">Meetings</a></li>
+        <li><a href="beginner.html">Beginners Guide</a></li>
+        <li><a href="practicetools.html">Practice Tools</a></li>
+        <li><a href="calendar.html">Calendar</a></li>
+        <li><a href="resources.html">Resources Library</a></li>
+      </ul>
+    </li>
+
+    <li><a href="leadership.html">Leadership</a></li>
+    <li><a href="contact.html" aria-current="page">Contact</a></li>
+  </ul>
+</nav>
   </aside>
 
   <!-- ===== Hero ===== -->

--- a/equity.html
+++ b/equity.html
@@ -28,46 +28,47 @@
       </div>
 
       <!-- Desktop links center -->
-            <nav class="nav-links" aria-label="Primary">
-        <ul class="menu-root">
-          <li><a href="index.html">Home</a></li>
+            
+<nav class="nav-links" aria-label="Primary">
+  <ul class="menu-root">
+    <li><a href="index.html">Home</a></li>
+    <li><a href="members.html">Members</a></li>
 
-          <li class="has-submenu">
-            <a href="about.html" class="top-link" aria-haspopup="true" aria-expanded="false">About</a>
-            <ul class="submenu" role="menu" aria-label="About submenu">
-              <li role="none"><a role="menuitem" href="about.html#who-we-are">Who We Are</a></li>
-              <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
-              <li role="none"><a role="menuitem" href="about.html#meetings">Meetings & Attendance</a></li>
-              <li role="none"><a role="menuitem" href="equity.html" aria-current="page">Equity Policy</a></li>
-              <li role="none"><a role="menuitem" href="why-pdu.html">Why PDU</a></li>
-            </ul>
-          </li>
+    <li class="has-submenu">
+      <a href="about.html" class="top-link" aria-haspopup="true" aria-expanded="false">About</a>
+      <ul class="submenu" role="menu" aria-label="About submenu">
+        <li role="none"><a role="menuitem" href="about.html#who-we-are">Who We Are</a></li>
+        <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
+        <li role="none"><a role="menuitem" href="about.html#meetings">Meetings & Attendance</a></li>
+        <li role="none"><a role="menuitem" href="equity.html" aria-current="page">Equity Policy</a></li>
+        <li role="none"><a role="menuitem" href="why-pdu.html">Why PDU</a></li>
+      </ul>
+    </li>
 
-          <li class="has-submenu">
-            <a href="tournaments.html" class="top-link" aria-haspopup="true" aria-expanded="false">Tournaments</a>
-            <ul class="submenu" role="menu" aria-label="Tournaments submenu">
-              <li role="none"><a role="menuitem" href="tournaments.html#featured">Next Tournament</a></li>
-              <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
-            </ul>
-          </li>
+    <li class="has-submenu">
+      <a href="tournaments.html" class="top-link" aria-haspopup="true" aria-expanded="false">Tournaments</a>
+      <ul class="submenu" role="menu" aria-label="Tournaments submenu">
+        <li role="none"><a role="menuitem" href="tournaments.html#featured">Next Tournament</a></li>
+        <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
+      </ul>
+    </li>
 
-          <li class="has-submenu">
-            <a href="join.html" class="top-link" aria-haspopup="true" aria-expanded="false">Join Us</a>
-            <ul class="submenu" role="menu" aria-label="Join Us submenu">
-              <li role="none"><a role="menuitem" href="join.html#mailing">Mailing List</a></li>
-              <li role="none"><a role="menuitem" href="join.html#meetings">Meetings</a></li>
-              <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
-              <li role="none"><a role="menuitem" href="practicetools.html">Practice Tools</a></li>
-              <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
-              <li role="none"><a role="menuitem" href="resources.html">Resources Library</a></li>
-            </ul>
-          </li>
+    <li class="has-submenu">
+      <a href="join.html" class="top-link join-link" aria-haspopup="true" aria-expanded="false">Join Us</a>
+      <ul class="submenu" role="menu" aria-label="Join Us submenu">
+        <li role="none"><a role="menuitem" href="join.html#mailing">Mailing List</a></li>
+        <li role="none"><a role="menuitem" href="join.html#meetings">Meetings</a></li>
+        <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
+        <li role="none"><a role="menuitem" href="practicetools.html">Practice Tools</a></li>
+        <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
+        <li role="none"><a role="menuitem" href="resources.html">Resources Library</a></li>
+      </ul>
+    </li>
 
-          <li><a href="leadership.html">Leadership</a></li>
-          <li><a href="members.html">Members</a></li>
-          <li><a href="contact.html">Contact</a></li>
-        </ul>
-      </nav>
+    <li><a href="leadership.html">Leadership</a></li>
+    <li><a href="contact.html">Contact</a></li>
+  </ul>
+</nav>
 
       <!-- PDU (centered on mobile) -->
       <div class="nav-left">
@@ -89,47 +90,48 @@
       <span>Menu</span>
       <button id="drawerClose" class="drawer-close" aria-label="Close menu">×</button>
     </div>
-        <nav class="drawer-nav" aria-label="Mobile">
-      <ul class="drawer-list">
-        <li><a href="index.html">Home</a></li>
+        
+<nav class="drawer-nav" aria-label="Mobile">
+  <ul class="drawer-list">
+    <li><a href="index.html">Home</a></li>
+    <li><a href="members.html">Members</a></li>
 
-        <li class="drawer-group">
-          <button class="drawer-toggle" aria-expanded="false">About</button>
-          <ul class="drawer-submenu">
-            <li><a href="about.html#who-we-are">Who We Are</a></li>
-            <li><a href="beginner.html">Beginners Guide</a></li>
-            <li><a href="about.html#meetings">Meetings & Attendance</a></li>
-            <li><a href="equity.html">Equity Policy</a></li>
-            <li><a href="why-pdu.html">Why PDU</a></li>
-          </ul>
-        </li>
-
-        <li class="drawer-group">
-          <button class="drawer-toggle" aria-expanded="false">Tournaments</button>
-          <ul class="drawer-submenu">
-            <li><a href="tournaments.html#featured">Next Tournament</a></li>
-            <li><a href="tournaments.html">Upcoming</a></li>
-            <li><a href="calendar.html">Calendar</a></li>
-          </ul>
-        </li>
-
-        <li class="drawer-group">
-          <button class="drawer-toggle" aria-expanded="false">Join Us</button>
-          <ul class="drawer-submenu">
-            <li><a href="join.html#mailing">Mailing List</a></li>
-            <li><a href="join.html#meetings">Meetings</a></li>
-            <li><a href="beginner.html">Beginners Guide</a></li>
-            <li><a href="practicetools.html">Practice Tools</a></li>
-            <li><a href="calendar.html">Calendar</a></li>
-            <li><a href="resources.html">Resources Library</a></li>
-          </ul>
-        </li>
-
-        <li><a href="leadership.html">Leadership</a></li>
-        <li><a href="members.html">Members</a></li>
-        <li><a href="contact.html">Contact</a></li>
+    <li class="drawer-group">
+      <button class="drawer-toggle" aria-expanded="false">About</button>
+      <ul class="drawer-submenu">
+        <li><a href="about.html#who-we-are">Who We Are</a></li>
+        <li><a href="beginner.html">Beginners Guide</a></li>
+        <li><a href="about.html#meetings">Meetings & Attendance</a></li>
+        <li><a href="equity.html" aria-current="page">Equity Policy</a></li>
+        <li><a href="why-pdu.html">Why PDU</a></li>
       </ul>
-    </nav>
+    </li>
+
+    <li class="drawer-group">
+      <button class="drawer-toggle" aria-expanded="false">Tournaments</button>
+      <ul class="drawer-submenu">
+        <li><a href="tournaments.html#featured">Next Tournament</a></li>
+        <li><a href="tournaments.html">Upcoming</a></li>
+        <li><a href="calendar.html">Calendar</a></li>
+      </ul>
+    </li>
+
+    <li class="drawer-group">
+      <button class="drawer-toggle join-link" aria-expanded="false">Join Us</button>
+      <ul class="drawer-submenu">
+        <li><a href="join.html#mailing">Mailing List</a></li>
+        <li><a href="join.html#meetings">Meetings</a></li>
+        <li><a href="beginner.html">Beginners Guide</a></li>
+        <li><a href="practicetools.html">Practice Tools</a></li>
+        <li><a href="calendar.html">Calendar</a></li>
+        <li><a href="resources.html">Resources Library</a></li>
+      </ul>
+    </li>
+
+    <li><a href="leadership.html">Leadership</a></li>
+    <li><a href="contact.html">Contact</a></li>
+  </ul>
+</nav>
   </aside>
 
   <!-- Hero -->

--- a/index.html
+++ b/index.html
@@ -80,46 +80,47 @@
         <img src="NYU_Short_RGB_White.png" alt="NYU Logo" class="logo-nyu" />
       </div>
 
-      <nav class="nav-links" aria-label="Primary">
-        <ul class="menu-root">
-          <li><a href="index.html" aria-current="page">Home</a></li>
+      
+<nav class="nav-links" aria-label="Primary">
+  <ul class="menu-root">
+    <li><a href="index.html" aria-current="page">Home</a></li>
+    <li><a href="members.html">Members</a></li>
 
-          <li class="has-submenu">
-            <a href="about.html" class="top-link" aria-haspopup="true" aria-expanded="false">About</a>
-            <ul class="submenu" role="menu" aria-label="About submenu">
-              <li role="none"><a role="menuitem" href="about.html#who-we-are">Who We Are</a></li>
-              <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
-              <li role="none"><a role="menuitem" href="about.html#meetings">Meetings & Attendance</a></li>
-              <li role="none"><a role="menuitem" href="equity.html">Equity Policy</a></li>
-              <li role="none"><a role="menuitem" href="why-pdu.html">Why PDU</a></li>
-            </ul>
-          </li>
+    <li class="has-submenu">
+      <a href="about.html" class="top-link" aria-haspopup="true" aria-expanded="false">About</a>
+      <ul class="submenu" role="menu" aria-label="About submenu">
+        <li role="none"><a role="menuitem" href="about.html#who-we-are">Who We Are</a></li>
+        <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
+        <li role="none"><a role="menuitem" href="about.html#meetings">Meetings & Attendance</a></li>
+        <li role="none"><a role="menuitem" href="equity.html">Equity Policy</a></li>
+        <li role="none"><a role="menuitem" href="why-pdu.html">Why PDU</a></li>
+      </ul>
+    </li>
 
-          <li class="has-submenu">
-            <a href="tournaments.html" class="top-link" aria-haspopup="true" aria-expanded="false">Tournaments</a>
-            <ul class="submenu" role="menu" aria-label="Tournaments submenu">
-              <li role="none"><a role="menuitem" href="tournaments.html#featured">Next Tournament</a></li>
-              <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
-            </ul>
-          </li>
+    <li class="has-submenu">
+      <a href="tournaments.html" class="top-link" aria-haspopup="true" aria-expanded="false">Tournaments</a>
+      <ul class="submenu" role="menu" aria-label="Tournaments submenu">
+        <li role="none"><a role="menuitem" href="tournaments.html#featured">Next Tournament</a></li>
+        <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
+      </ul>
+    </li>
 
-          <li class="has-submenu">
-            <a href="join.html" class="top-link" aria-haspopup="true" aria-expanded="false">Join Us</a>
-            <ul class="submenu" role="menu" aria-label="Join Us submenu">
-              <li role="none"><a role="menuitem" href="join.html#mailing">Mailing List</a></li>
-              <li role="none"><a role="menuitem" href="join.html#meetings">Meetings</a></li>
-              <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
-              <li role="none"><a role="menuitem" href="practicetools.html">Practice Tools</a></li>
-              <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
-              <li role="none"><a role="menuitem" href="resources.html">Resources Library</a></li>
-            </ul>
-          </li>
+    <li class="has-submenu">
+      <a href="join.html" class="top-link join-link" aria-haspopup="true" aria-expanded="false">Join Us</a>
+      <ul class="submenu" role="menu" aria-label="Join Us submenu">
+        <li role="none"><a role="menuitem" href="join.html#mailing">Mailing List</a></li>
+        <li role="none"><a role="menuitem" href="join.html#meetings">Meetings</a></li>
+        <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
+        <li role="none"><a role="menuitem" href="practicetools.html">Practice Tools</a></li>
+        <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
+        <li role="none"><a role="menuitem" href="resources.html">Resources Library</a></li>
+      </ul>
+    </li>
 
-          <li><a href="leadership.html">Leadership</a></li>
-          <li><a href="members.html">Members</a></li>
-          <li><a href="contact.html">Contact</a></li>
-        </ul>
-      </nav>
+    <li><a href="leadership.html">Leadership</a></li>
+    <li><a href="contact.html">Contact</a></li>
+  </ul>
+</nav>
 
       <div class="nav-left">
         <a href="index.html" aria-label="Home" class="brand-link">
@@ -139,47 +140,48 @@
       <span>Menu</span>
       <button id="drawerClose" class="drawer-close" aria-label="Close menu">×</button>
     </div>
-    <nav class="drawer-nav" aria-label="Mobile">
-      <ul class="drawer-list">
-        <li><a href="index.html">Home</a></li>
+    
+<nav class="drawer-nav" aria-label="Mobile">
+  <ul class="drawer-list">
+    <li><a href="index.html" aria-current="page">Home</a></li>
+    <li><a href="members.html">Members</a></li>
 
-        <li class="drawer-group">
-          <button class="drawer-toggle" aria-expanded="false">About</button>
-          <ul class="drawer-submenu">
-            <li><a href="about.html#who-we-are">Who We Are</a></li>
-            <li><a href="beginner.html">Beginners Guide</a></li>
-            <li><a href="about.html#meetings">Meetings & Attendance</a></li>
-            <li><a href="equity.html">Equity Policy</a></li>
-            <li><a href="why-pdu.html">Why PDU</a></li>
-          </ul>
-        </li>
-
-        <li class="drawer-group">
-          <button class="drawer-toggle" aria-expanded="false">Tournaments</button>
-          <ul class="drawer-submenu">
-            <li><a href="tournaments.html#featured">Next Tournament</a></li>
-            <li><a href="tournaments.html">Upcoming</a></li>
-            <li><a href="calendar.html">Calendar</a></li>
-          </ul>
-        </li>
-
-        <li class="drawer-group">
-          <button class="drawer-toggle" aria-expanded="false">Join Us</button>
-          <ul class="drawer-submenu">
-            <li><a href="join.html#mailing">Mailing List</a></li>
-            <li><a href="join.html#meetings">Meetings</a></li>
-            <li><a href="beginner.html">Beginners Guide</a></li>
-            <li><a href="practicetools.html">Practice Tools</a></li>
-            <li><a href="calendar.html">Calendar</a></li>
-            <li><a href="resources.html">Resources Library</a></li>
-          </ul>
-        </li>
-
-        <li><a href="leadership.html">Leadership</a></li>
-        <li><a href="members.html">Members</a></li>
-        <li><a href="contact.html">Contact</a></li>
+    <li class="drawer-group">
+      <button class="drawer-toggle" aria-expanded="false">About</button>
+      <ul class="drawer-submenu">
+        <li><a href="about.html#who-we-are">Who We Are</a></li>
+        <li><a href="beginner.html">Beginners Guide</a></li>
+        <li><a href="about.html#meetings">Meetings & Attendance</a></li>
+        <li><a href="equity.html">Equity Policy</a></li>
+        <li><a href="why-pdu.html">Why PDU</a></li>
       </ul>
-    </nav>
+    </li>
+
+    <li class="drawer-group">
+      <button class="drawer-toggle" aria-expanded="false">Tournaments</button>
+      <ul class="drawer-submenu">
+        <li><a href="tournaments.html#featured">Next Tournament</a></li>
+        <li><a href="tournaments.html">Upcoming</a></li>
+        <li><a href="calendar.html">Calendar</a></li>
+      </ul>
+    </li>
+
+    <li class="drawer-group">
+      <button class="drawer-toggle join-link" aria-expanded="false">Join Us</button>
+      <ul class="drawer-submenu">
+        <li><a href="join.html#mailing">Mailing List</a></li>
+        <li><a href="join.html#meetings">Meetings</a></li>
+        <li><a href="beginner.html">Beginners Guide</a></li>
+        <li><a href="practicetools.html">Practice Tools</a></li>
+        <li><a href="calendar.html">Calendar</a></li>
+        <li><a href="resources.html">Resources Library</a></li>
+      </ul>
+    </li>
+
+    <li><a href="leadership.html">Leadership</a></li>
+    <li><a href="contact.html">Contact</a></li>
+  </ul>
+</nav>
   </aside>
 
   <!-- Hero -->

--- a/join.html
+++ b/join.html
@@ -179,46 +179,47 @@
         <img src="NYU_Short_RGB_White.png" alt="NYU Logo" class="logo-nyu" />
       </div>
 
-            <nav class="nav-links" aria-label="Primary">
-        <ul class="menu-root">
-          <li><a href="index.html">Home</a></li>
+            
+<nav class="nav-links" aria-label="Primary">
+  <ul class="menu-root">
+    <li><a href="index.html">Home</a></li>
+    <li><a href="members.html">Members</a></li>
 
-          <li class="has-submenu">
-            <a href="about.html" class="top-link" aria-haspopup="true" aria-expanded="false">About</a>
-            <ul class="submenu" role="menu" aria-label="About submenu">
-              <li role="none"><a role="menuitem" href="about.html#who-we-are">Who We Are</a></li>
-              <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
-              <li role="none"><a role="menuitem" href="about.html#meetings">Meetings & Attendance</a></li>
-              <li role="none"><a role="menuitem" href="equity.html">Equity Policy</a></li>
-              <li role="none"><a role="menuitem" href="why-pdu.html">Why PDU</a></li>
-            </ul>
-          </li>
+    <li class="has-submenu">
+      <a href="about.html" class="top-link" aria-haspopup="true" aria-expanded="false">About</a>
+      <ul class="submenu" role="menu" aria-label="About submenu">
+        <li role="none"><a role="menuitem" href="about.html#who-we-are">Who We Are</a></li>
+        <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
+        <li role="none"><a role="menuitem" href="about.html#meetings">Meetings & Attendance</a></li>
+        <li role="none"><a role="menuitem" href="equity.html">Equity Policy</a></li>
+        <li role="none"><a role="menuitem" href="why-pdu.html">Why PDU</a></li>
+      </ul>
+    </li>
 
-          <li class="has-submenu">
-            <a href="tournaments.html" class="top-link" aria-haspopup="true" aria-expanded="false">Tournaments</a>
-            <ul class="submenu" role="menu" aria-label="Tournaments submenu">
-              <li role="none"><a role="menuitem" href="tournaments.html#featured">Next Tournament</a></li>
-              <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
-            </ul>
-          </li>
+    <li class="has-submenu">
+      <a href="tournaments.html" class="top-link" aria-haspopup="true" aria-expanded="false">Tournaments</a>
+      <ul class="submenu" role="menu" aria-label="Tournaments submenu">
+        <li role="none"><a role="menuitem" href="tournaments.html#featured">Next Tournament</a></li>
+        <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
+      </ul>
+    </li>
 
-          <li class="has-submenu">
-            <a href="join.html" class="top-link" aria-haspopup="true" aria-expanded="false" aria-current="page">Join Us</a>
-            <ul class="submenu" role="menu" aria-label="Join Us submenu">
-              <li role="none"><a role="menuitem" href="join.html#mailing">Mailing List</a></li>
-              <li role="none"><a role="menuitem" href="join.html#meetings">Meetings</a></li>
-              <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
-              <li role="none"><a role="menuitem" href="practicetools.html">Practice Tools</a></li>
-              <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
-              <li role="none"><a role="menuitem" href="resources.html">Resources Library</a></li>
-            </ul>
-          </li>
+    <li class="has-submenu">
+      <a href="join.html" class="top-link join-link" aria-current="page" aria-haspopup="true" aria-expanded="false">Join Us</a>
+      <ul class="submenu" role="menu" aria-label="Join Us submenu">
+        <li role="none"><a role="menuitem" href="join.html#mailing">Mailing List</a></li>
+        <li role="none"><a role="menuitem" href="join.html#meetings">Meetings</a></li>
+        <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
+        <li role="none"><a role="menuitem" href="practicetools.html">Practice Tools</a></li>
+        <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
+        <li role="none"><a role="menuitem" href="resources.html">Resources Library</a></li>
+      </ul>
+    </li>
 
-          <li><a href="leadership.html">Leadership</a></li>
-          <li><a href="members.html">Members</a></li>
-          <li><a href="contact.html">Contact</a></li>
-        </ul>
-      </nav>
+    <li><a href="leadership.html">Leadership</a></li>
+    <li><a href="contact.html">Contact</a></li>
+  </ul>
+</nav>
 
       <div class="nav-left">
         <a href="index.html" aria-label="Home" class="brand-link">
@@ -238,47 +239,48 @@
       <span>Menu</span>
       <button id="drawerClose" class="drawer-close" aria-label="Close menu">×</button>
     </div>
-        <nav class="drawer-nav" aria-label="Mobile">
-      <ul class="drawer-list">
-        <li><a href="index.html">Home</a></li>
+        
+<nav class="drawer-nav" aria-label="Mobile">
+  <ul class="drawer-list">
+    <li><a href="index.html">Home</a></li>
+    <li><a href="members.html">Members</a></li>
 
-        <li class="drawer-group">
-          <button class="drawer-toggle" aria-expanded="false">About</button>
-          <ul class="drawer-submenu">
-            <li><a href="about.html#who-we-are">Who We Are</a></li>
-            <li><a href="beginner.html">Beginners Guide</a></li>
-            <li><a href="about.html#meetings">Meetings & Attendance</a></li>
-            <li><a href="equity.html">Equity Policy</a></li>
-            <li><a href="why-pdu.html">Why PDU</a></li>
-          </ul>
-        </li>
-
-        <li class="drawer-group">
-          <button class="drawer-toggle" aria-expanded="false">Tournaments</button>
-          <ul class="drawer-submenu">
-            <li><a href="tournaments.html#featured">Next Tournament</a></li>
-            <li><a href="tournaments.html">Upcoming</a></li>
-            <li><a href="calendar.html">Calendar</a></li>
-          </ul>
-        </li>
-
-        <li class="drawer-group">
-          <button class="drawer-toggle" aria-expanded="false">Join Us</button>
-          <ul class="drawer-submenu">
-            <li><a href="join.html#mailing">Mailing List</a></li>
-            <li><a href="join.html#meetings">Meetings</a></li>
-            <li><a href="beginner.html">Beginners Guide</a></li>
-            <li><a href="practicetools.html">Practice Tools</a></li>
-            <li><a href="calendar.html">Calendar</a></li>
-            <li><a href="resources.html">Resources Library</a></li>
-          </ul>
-        </li>
-
-        <li><a href="leadership.html">Leadership</a></li>
-        <li><a href="members.html">Members</a></li>
-        <li><a href="contact.html">Contact</a></li>
+    <li class="drawer-group">
+      <button class="drawer-toggle" aria-expanded="false">About</button>
+      <ul class="drawer-submenu">
+        <li><a href="about.html#who-we-are">Who We Are</a></li>
+        <li><a href="beginner.html">Beginners Guide</a></li>
+        <li><a href="about.html#meetings">Meetings & Attendance</a></li>
+        <li><a href="equity.html">Equity Policy</a></li>
+        <li><a href="why-pdu.html">Why PDU</a></li>
       </ul>
-    </nav>
+    </li>
+
+    <li class="drawer-group">
+      <button class="drawer-toggle" aria-expanded="false">Tournaments</button>
+      <ul class="drawer-submenu">
+        <li><a href="tournaments.html#featured">Next Tournament</a></li>
+        <li><a href="tournaments.html">Upcoming</a></li>
+        <li><a href="calendar.html">Calendar</a></li>
+      </ul>
+    </li>
+
+    <li class="drawer-group">
+      <button class="drawer-toggle join-link" aria-current="page" aria-expanded="false">Join Us</button>
+      <ul class="drawer-submenu">
+        <li><a href="join.html#mailing">Mailing List</a></li>
+        <li><a href="join.html#meetings">Meetings</a></li>
+        <li><a href="beginner.html">Beginners Guide</a></li>
+        <li><a href="practicetools.html">Practice Tools</a></li>
+        <li><a href="calendar.html">Calendar</a></li>
+        <li><a href="resources.html">Resources Library</a></li>
+      </ul>
+    </li>
+
+    <li><a href="leadership.html">Leadership</a></li>
+    <li><a href="contact.html">Contact</a></li>
+  </ul>
+</nav>
   </aside>
 
   <!-- Friendly one-time intro overlay -->

--- a/judging.html
+++ b/judging.html
@@ -193,46 +193,47 @@
         <img src="NYU_Short_RGB_White.png" alt="NYU Logo" class="logo-nyu" />
       </div>
 
-            <nav class="nav-links" aria-label="Primary">
-        <ul class="menu-root">
-          <li><a href="index.html">Home</a></li>
+            
+<nav class="nav-links" aria-label="Primary">
+  <ul class="menu-root">
+    <li><a href="index.html">Home</a></li>
+    <li><a href="members.html">Members</a></li>
 
-          <li class="has-submenu">
-            <a href="about.html" class="top-link" aria-haspopup="true" aria-expanded="false">About</a>
-            <ul class="submenu" role="menu" aria-label="About submenu">
-              <li role="none"><a role="menuitem" href="about.html#who-we-are">Who We Are</a></li>
-              <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
-              <li role="none"><a role="menuitem" href="about.html#meetings">Meetings & Attendance</a></li>
-              <li role="none"><a role="menuitem" href="equity.html">Equity Policy</a></li>
-              <li role="none"><a role="menuitem" href="why-pdu.html">Why PDU</a></li>
-            </ul>
-          </li>
+    <li class="has-submenu">
+      <a href="about.html" class="top-link" aria-haspopup="true" aria-expanded="false">About</a>
+      <ul class="submenu" role="menu" aria-label="About submenu">
+        <li role="none"><a role="menuitem" href="about.html#who-we-are">Who We Are</a></li>
+        <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
+        <li role="none"><a role="menuitem" href="about.html#meetings">Meetings & Attendance</a></li>
+        <li role="none"><a role="menuitem" href="equity.html">Equity Policy</a></li>
+        <li role="none"><a role="menuitem" href="why-pdu.html">Why PDU</a></li>
+      </ul>
+    </li>
 
-          <li class="has-submenu">
-            <a href="tournaments.html" class="top-link" aria-haspopup="true" aria-expanded="false">Tournaments</a>
-            <ul class="submenu" role="menu" aria-label="Tournaments submenu">
-              <li role="none"><a role="menuitem" href="tournaments.html#featured">Next Tournament</a></li>
-              <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
-            </ul>
-          </li>
+    <li class="has-submenu">
+      <a href="tournaments.html" class="top-link" aria-haspopup="true" aria-expanded="false">Tournaments</a>
+      <ul class="submenu" role="menu" aria-label="Tournaments submenu">
+        <li role="none"><a role="menuitem" href="tournaments.html#featured">Next Tournament</a></li>
+        <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
+      </ul>
+    </li>
 
-          <li class="has-submenu">
-            <a href="join.html" class="top-link" aria-haspopup="true" aria-expanded="false">Join Us</a>
-            <ul class="submenu" role="menu" aria-label="Join Us submenu">
-              <li role="none"><a role="menuitem" href="join.html#mailing">Mailing List</a></li>
-              <li role="none"><a role="menuitem" href="join.html#meetings">Meetings</a></li>
-              <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
-              <li role="none"><a role="menuitem" href="practicetools.html">Practice Tools</a></li>
-              <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
-              <li role="none"><a role="menuitem" href="resources.html">Resources Library</a></li>
-            </ul>
-          </li>
+    <li class="has-submenu">
+      <a href="join.html" class="top-link join-link" aria-haspopup="true" aria-expanded="false">Join Us</a>
+      <ul class="submenu" role="menu" aria-label="Join Us submenu">
+        <li role="none"><a role="menuitem" href="join.html#mailing">Mailing List</a></li>
+        <li role="none"><a role="menuitem" href="join.html#meetings">Meetings</a></li>
+        <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
+        <li role="none"><a role="menuitem" href="practicetools.html">Practice Tools</a></li>
+        <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
+        <li role="none"><a role="menuitem" href="resources.html">Resources Library</a></li>
+      </ul>
+    </li>
 
-          <li><a href="leadership.html">Leadership</a></li>
-          <li><a href="members.html">Members</a></li>
-          <li><a href="contact.html">Contact</a></li>
-        </ul>
-      </nav>
+    <li><a href="leadership.html">Leadership</a></li>
+    <li><a href="contact.html">Contact</a></li>
+  </ul>
+</nav>
 
       <div class="nav-left">
         <a href="index.html" aria-label="Home" class="brand-link">
@@ -252,47 +253,48 @@
       <span>Menu</span>
       <button id="drawerClose" class="drawer-close" aria-label="Close menu">×</button>
     </div>
-        <nav class="drawer-nav" aria-label="Mobile">
-      <ul class="drawer-list">
-        <li><a href="index.html">Home</a></li>
+        
+<nav class="drawer-nav" aria-label="Mobile">
+  <ul class="drawer-list">
+    <li><a href="index.html">Home</a></li>
+    <li><a href="members.html">Members</a></li>
 
-        <li class="drawer-group">
-          <button class="drawer-toggle" aria-expanded="false">About</button>
-          <ul class="drawer-submenu">
-            <li><a href="about.html#who-we-are">Who We Are</a></li>
-            <li><a href="beginner.html">Beginners Guide</a></li>
-            <li><a href="about.html#meetings">Meetings & Attendance</a></li>
-            <li><a href="equity.html">Equity Policy</a></li>
-            <li><a href="why-pdu.html">Why PDU</a></li>
-          </ul>
-        </li>
-
-        <li class="drawer-group">
-          <button class="drawer-toggle" aria-expanded="false">Tournaments</button>
-          <ul class="drawer-submenu">
-            <li><a href="tournaments.html#featured">Next Tournament</a></li>
-            <li><a href="tournaments.html">Upcoming</a></li>
-            <li><a href="calendar.html">Calendar</a></li>
-          </ul>
-        </li>
-
-        <li class="drawer-group">
-          <button class="drawer-toggle" aria-expanded="false">Join Us</button>
-          <ul class="drawer-submenu">
-            <li><a href="join.html#mailing">Mailing List</a></li>
-            <li><a href="join.html#meetings">Meetings</a></li>
-            <li><a href="beginner.html">Beginners Guide</a></li>
-            <li><a href="practicetools.html">Practice Tools</a></li>
-            <li><a href="calendar.html">Calendar</a></li>
-            <li><a href="resources.html">Resources Library</a></li>
-          </ul>
-        </li>
-
-        <li><a href="leadership.html">Leadership</a></li>
-        <li><a href="members.html">Members</a></li>
-        <li><a href="contact.html">Contact</a></li>
+    <li class="drawer-group">
+      <button class="drawer-toggle" aria-expanded="false">About</button>
+      <ul class="drawer-submenu">
+        <li><a href="about.html#who-we-are">Who We Are</a></li>
+        <li><a href="beginner.html">Beginners Guide</a></li>
+        <li><a href="about.html#meetings">Meetings & Attendance</a></li>
+        <li><a href="equity.html">Equity Policy</a></li>
+        <li><a href="why-pdu.html">Why PDU</a></li>
       </ul>
-    </nav>
+    </li>
+
+    <li class="drawer-group">
+      <button class="drawer-toggle" aria-expanded="false">Tournaments</button>
+      <ul class="drawer-submenu">
+        <li><a href="tournaments.html#featured">Next Tournament</a></li>
+        <li><a href="tournaments.html">Upcoming</a></li>
+        <li><a href="calendar.html">Calendar</a></li>
+      </ul>
+    </li>
+
+    <li class="drawer-group">
+      <button class="drawer-toggle join-link" aria-expanded="false">Join Us</button>
+      <ul class="drawer-submenu">
+        <li><a href="join.html#mailing">Mailing List</a></li>
+        <li><a href="join.html#meetings">Meetings</a></li>
+        <li><a href="beginner.html">Beginners Guide</a></li>
+        <li><a href="practicetools.html">Practice Tools</a></li>
+        <li><a href="calendar.html">Calendar</a></li>
+        <li><a href="resources.html">Resources Library</a></li>
+      </ul>
+    </li>
+
+    <li><a href="leadership.html">Leadership</a></li>
+    <li><a href="contact.html">Contact</a></li>
+  </ul>
+</nav>
   </aside>
 
   <!-- ============== HERO ============== -->

--- a/leadership.html
+++ b/leadership.html
@@ -204,46 +204,47 @@
       </div>
 
       <!-- Desktop links center -->
-      <nav class="nav-links" aria-label="Primary">
-        <ul class="menu-root">
-          <li><a href="index.html">Home</a></li>
+      
+<nav class="nav-links" aria-label="Primary">
+  <ul class="menu-root">
+    <li><a href="index.html">Home</a></li>
+    <li><a href="members.html">Members</a></li>
 
-          <li class="has-submenu">
-            <a href="about.html" class="top-link" aria-haspopup="true" aria-expanded="false">About</a>
-            <ul class="submenu" role="menu" aria-label="About submenu">
-              <li role="none"><a role="menuitem" href="about.html#who-we-are">Who We Are</a></li>
-              <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
-              <li role="none"><a role="menuitem" href="about.html#meetings">Meetings & Attendance</a></li>
-              <li role="none"><a role="menuitem" href="equity.html">Equity Policy</a></li>
-              <li role="none"><a role="menuitem" href="why-pdu.html">Why PDU</a></li>
-            </ul>
-          </li>
+    <li class="has-submenu">
+      <a href="about.html" class="top-link" aria-haspopup="true" aria-expanded="false">About</a>
+      <ul class="submenu" role="menu" aria-label="About submenu">
+        <li role="none"><a role="menuitem" href="about.html#who-we-are">Who We Are</a></li>
+        <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
+        <li role="none"><a role="menuitem" href="about.html#meetings">Meetings & Attendance</a></li>
+        <li role="none"><a role="menuitem" href="equity.html">Equity Policy</a></li>
+        <li role="none"><a role="menuitem" href="why-pdu.html">Why PDU</a></li>
+      </ul>
+    </li>
 
-          <li class="has-submenu">
-            <a href="tournaments.html" class="top-link" aria-haspopup="true" aria-expanded="false">Tournaments</a>
-            <ul class="submenu" role="menu" aria-label="Tournaments submenu">
-              <li role="none"><a role="menuitem" href="tournaments.html#featured">Next Tournament</a></li>
-              <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
-            </ul>
-          </li>
+    <li class="has-submenu">
+      <a href="tournaments.html" class="top-link" aria-haspopup="true" aria-expanded="false">Tournaments</a>
+      <ul class="submenu" role="menu" aria-label="Tournaments submenu">
+        <li role="none"><a role="menuitem" href="tournaments.html#featured">Next Tournament</a></li>
+        <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
+      </ul>
+    </li>
 
-          <li class="has-submenu">
-            <a href="join.html" class="top-link" aria-haspopup="true" aria-expanded="false">Join Us</a>
-            <ul class="submenu" role="menu" aria-label="Join Us submenu">
-              <li role="none"><a role="menuitem" href="join.html#mailing">Mailing List</a></li>
-              <li role="none"><a role="menuitem" href="join.html#meetings">Meetings</a></li>
-              <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
-              <li role="none"><a role="menuitem" href="practicetools.html">Practice Tools</a></li>
-              <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
-              <li role="none"><a role="menuitem" href="resources.html">Resources Library</a></li>
-            </ul>
-          </li>
+    <li class="has-submenu">
+      <a href="join.html" class="top-link join-link" aria-haspopup="true" aria-expanded="false">Join Us</a>
+      <ul class="submenu" role="menu" aria-label="Join Us submenu">
+        <li role="none"><a role="menuitem" href="join.html#mailing">Mailing List</a></li>
+        <li role="none"><a role="menuitem" href="join.html#meetings">Meetings</a></li>
+        <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
+        <li role="none"><a role="menuitem" href="practicetools.html">Practice Tools</a></li>
+        <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
+        <li role="none"><a role="menuitem" href="resources.html">Resources Library</a></li>
+      </ul>
+    </li>
 
-          <li><a href="leadership.html" aria-current="page">Leadership</a></li>
-          <li><a href="members.html">Members</a></li>
-          <li><a href="contact.html">Contact</a></li>
-        </ul>
-      </nav>
+    <li><a href="leadership.html" aria-current="page">Leadership</a></li>
+    <li><a href="contact.html">Contact</a></li>
+  </ul>
+</nav>
 
       <!-- PDU logo (left on desktop; centered on mobile) -->
       <div class="nav-left">
@@ -265,47 +266,48 @@
       <span>Menu</span>
       <button id="drawerClose" class="drawer-close" aria-label="Close menu">×</button>
     </div>
-    <nav class="drawer-nav" aria-label="Mobile">
-      <ul class="drawer-list">
-        <li><a href="index.html">Home</a></li>
+    
+<nav class="drawer-nav" aria-label="Mobile">
+  <ul class="drawer-list">
+    <li><a href="index.html">Home</a></li>
+    <li><a href="members.html">Members</a></li>
 
-        <li class="drawer-group">
-          <button class="drawer-toggle" aria-expanded="false">About</button>
-          <ul class="drawer-submenu">
-            <li><a href="about.html#who-we-are">Who We Are</a></li>
-            <li><a href="beginner.html">Beginners Guide</a></li>
-            <li><a href="about.html#meetings">Meetings & Attendance</a></li>
-            <li><a href="equity.html">Equity Policy</a></li>
-            <li><a href="why-pdu.html">Why PDU</a></li>
-          </ul>
-        </li>
-
-        <li class="drawer-group">
-          <button class="drawer-toggle" aria-expanded="false">Tournaments</button>
-          <ul class="drawer-submenu">
-            <li><a href="tournaments.html#featured">Next Tournament</a></li>
-            <li><a href="tournaments.html">Upcoming</a></li>
-            <li><a href="calendar.html">Calendar</a></li>
-          </ul>
-        </li>
-
-        <li class="drawer-group">
-          <button class="drawer-toggle" aria-expanded="false">Join Us</button>
-          <ul class="drawer-submenu">
-            <li><a href="join.html#mailing">Mailing List</a></li>
-            <li><a href="join.html#meetings">Meetings</a></li>
-            <li><a href="beginner.html">Beginners Guide</a></li>
-            <li><a href="practicetools.html">Practice Tools</a></li>
-            <li><a href="calendar.html">Calendar</a></li>
-            <li><a href="resources.html">Resources Library</a></li>
-          </ul>
-        </li>
-
-        <li><a href="leadership.html" aria-current="page">Leadership</a></li>
-        <li><a href="members.html">Members</a></li>
-        <li><a href="contact.html">Contact</a></li>
+    <li class="drawer-group">
+      <button class="drawer-toggle" aria-expanded="false">About</button>
+      <ul class="drawer-submenu">
+        <li><a href="about.html#who-we-are">Who We Are</a></li>
+        <li><a href="beginner.html">Beginners Guide</a></li>
+        <li><a href="about.html#meetings">Meetings & Attendance</a></li>
+        <li><a href="equity.html">Equity Policy</a></li>
+        <li><a href="why-pdu.html">Why PDU</a></li>
       </ul>
-    </nav>
+    </li>
+
+    <li class="drawer-group">
+      <button class="drawer-toggle" aria-expanded="false">Tournaments</button>
+      <ul class="drawer-submenu">
+        <li><a href="tournaments.html#featured">Next Tournament</a></li>
+        <li><a href="tournaments.html">Upcoming</a></li>
+        <li><a href="calendar.html">Calendar</a></li>
+      </ul>
+    </li>
+
+    <li class="drawer-group">
+      <button class="drawer-toggle join-link" aria-expanded="false">Join Us</button>
+      <ul class="drawer-submenu">
+        <li><a href="join.html#mailing">Mailing List</a></li>
+        <li><a href="join.html#meetings">Meetings</a></li>
+        <li><a href="beginner.html">Beginners Guide</a></li>
+        <li><a href="practicetools.html">Practice Tools</a></li>
+        <li><a href="calendar.html">Calendar</a></li>
+        <li><a href="resources.html">Resources Library</a></li>
+      </ul>
+    </li>
+
+    <li><a href="leadership.html" aria-current="page">Leadership</a></li>
+    <li><a href="contact.html">Contact</a></li>
+  </ul>
+</nav>
   </aside>
 
   <!-- Hero -->

--- a/members.html
+++ b/members.html
@@ -113,41 +113,47 @@
         <img src="NYU_Short_RGB_White.png" alt="NYU Logo" class="logo-nyu" />
       </div>
 
-      <nav class="nav-links" aria-label="Primary">
-        <ul class="menu-root">
-          <li><a href="index.html">Home</a></li>
+      
+<nav class="nav-links" aria-label="Primary">
+  <ul class="menu-root">
+    <li><a href="index.html">Home</a></li>
+    <li><a href="members.html" aria-current="page">Members</a></li>
 
-          <li class="has-submenu">
-            <a href="about.html" class="top-link" aria-haspopup="true" aria-expanded="false">About</a>
-            <ul class="submenu" role="menu" aria-label="About submenu">
-              <li role="none"><a role="menuitem" href="about.html#who-we-are">Who We Are</a></li>
-              <li role="none"><a role="menuitem" href="about.html#apda">What is APDA?</a></li>
-              <li role="none"><a role="menuitem" href="about.html#meetings">Meetings & Attendance</a></li>
-              <li role="none"><a role="menuitem" href="equity.html">Equity</a></li>
-              <li role="none"><a role="menuitem" href="why-pdu.html">Why PDU</a></li>
-            </ul>
-          </li>
+    <li class="has-submenu">
+      <a href="about.html" class="top-link" aria-haspopup="true" aria-expanded="false">About</a>
+      <ul class="submenu" role="menu" aria-label="About submenu">
+        <li role="none"><a role="menuitem" href="about.html#who-we-are">Who We Are</a></li>
+        <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
+        <li role="none"><a role="menuitem" href="about.html#meetings">Meetings & Attendance</a></li>
+        <li role="none"><a role="menuitem" href="equity.html">Equity Policy</a></li>
+        <li role="none"><a role="menuitem" href="why-pdu.html">Why PDU</a></li>
+      </ul>
+    </li>
 
-          <li><a href="tournaments.html">Tournaments</a></li>
+    <li class="has-submenu">
+      <a href="tournaments.html" class="top-link" aria-haspopup="true" aria-expanded="false">Tournaments</a>
+      <ul class="submenu" role="menu" aria-label="Tournaments submenu">
+        <li role="none"><a role="menuitem" href="tournaments.html#featured">Next Tournament</a></li>
+        <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
+      </ul>
+    </li>
 
-          <li class="has-submenu">
-            <a href="join.html" class="top-link" aria-haspopup="true" aria-expanded="false">Join Us</a>
-            <ul class="submenu" role="menu" aria-label="Join Us submenu">
-              <li role="none"><a role="menuitem" href="join.html#mailing">Mailing List</a></li>
-              <li role="none"><a role="menuitem" href="join.html#beginner-cta">Beginners</a></li>
-              <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
-              <li role="none"><a role="menuitem" href="join.html#meetings">Meetings (Monthly)</a></li>
-              <li role="none"><a role="menuitem" href="join.html#months">Month Cards</a></li>
-              <li role="none"><a role="menuitem" href="join.html#partners">Partners</a></li>
-              <li role="none"><a role="menuitem" href="join.html#myths">Costs & Support</a></li>
-            </ul>
-          </li>
+    <li class="has-submenu">
+      <a href="join.html" class="top-link join-link" aria-haspopup="true" aria-expanded="false">Join Us</a>
+      <ul class="submenu" role="menu" aria-label="Join Us submenu">
+        <li role="none"><a role="menuitem" href="join.html#mailing">Mailing List</a></li>
+        <li role="none"><a role="menuitem" href="join.html#meetings">Meetings</a></li>
+        <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
+        <li role="none"><a role="menuitem" href="practicetools.html">Practice Tools</a></li>
+        <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
+        <li role="none"><a role="menuitem" href="resources.html">Resources Library</a></li>
+      </ul>
+    </li>
 
-          <li><a href="leadership.html">Leadership</a></li>
-          <li><a href="members.html" aria-current="page">Members</a></li>
-          <li><a href="contact.html">Contact</a></li>
-        </ul>
-      </nav>
+    <li><a href="leadership.html">Leadership</a></li>
+    <li><a href="contact.html">Contact</a></li>
+  </ul>
+</nav>
 
       <div class="nav-left">
         <a href="index.html" aria-label="Home" class="brand-link">
@@ -167,41 +173,48 @@
       <span>Menu</span>
       <button id="drawerClose" class="drawer-close" aria-label="Close menu">×</button>
     </div>
-    <nav class="drawer-nav" aria-label="Mobile">
-      <ul class="drawer-list">
-        <li><a href="index.html">Home</a></li>
+    
+<nav class="drawer-nav" aria-label="Mobile">
+  <ul class="drawer-list">
+    <li><a href="index.html">Home</a></li>
+    <li><a href="members.html" aria-current="page">Members</a></li>
 
-        <li class="drawer-group">
-          <button class="drawer-toggle" aria-expanded="false">About</button>
-          <ul class="drawer-submenu">
-            <li><a href="about.html#who-we-are">Who We Are</a></li>
-            <li><a href="about.html#apda">What is APDA?</a></li>
-            <li><a href="about.html#meetings">Meetings & Attendance</a></li>
-            <li><a href="equity.html">Equity</a></li>
-            <li><a href="why-pdu.html">Why PDU</a></li>
-          </ul>
-        </li>
-
-        <li><a href="tournaments.html">Tournaments</a></li>
-
-        <li class="drawer-group">
-          <button class="drawer-toggle" aria-expanded="false">Join Us</button>
-          <ul class="drawer-submenu">
-            <li><a href="join.html#mailing">Mailing List</a></li>
-            <li><a href="join.html#beginner-cta">Beginners</a></li>
-            <li><a href="calendar.html">Calendar</a></li>
-            <li><a href="join.html#meetings">Meetings (Monthly)</a></li>
-            <li><a href="join.html#months">Month Cards</a></li>
-            <li><a href="join.html#partners">Partners</a></li>
-            <li><a href="join.html#myths">Costs & Support</a></li>
-          </ul>
-        </li>
-
-        <li><a href="leadership.html">Leadership</a></li>
-        <li><a href="members.html" aria-current="page">Members</a></li>
-        <li><a href="contact.html">Contact</a></li>
+    <li class="drawer-group">
+      <button class="drawer-toggle" aria-expanded="false">About</button>
+      <ul class="drawer-submenu">
+        <li><a href="about.html#who-we-are">Who We Are</a></li>
+        <li><a href="beginner.html">Beginners Guide</a></li>
+        <li><a href="about.html#meetings">Meetings & Attendance</a></li>
+        <li><a href="equity.html">Equity Policy</a></li>
+        <li><a href="why-pdu.html">Why PDU</a></li>
       </ul>
-    </nav>
+    </li>
+
+    <li class="drawer-group">
+      <button class="drawer-toggle" aria-expanded="false">Tournaments</button>
+      <ul class="drawer-submenu">
+        <li><a href="tournaments.html#featured">Next Tournament</a></li>
+        <li><a href="tournaments.html">Upcoming</a></li>
+        <li><a href="calendar.html">Calendar</a></li>
+      </ul>
+    </li>
+
+    <li class="drawer-group">
+      <button class="drawer-toggle join-link" aria-expanded="false">Join Us</button>
+      <ul class="drawer-submenu">
+        <li><a href="join.html#mailing">Mailing List</a></li>
+        <li><a href="join.html#meetings">Meetings</a></li>
+        <li><a href="beginner.html">Beginners Guide</a></li>
+        <li><a href="practicetools.html">Practice Tools</a></li>
+        <li><a href="calendar.html">Calendar</a></li>
+        <li><a href="resources.html">Resources Library</a></li>
+      </ul>
+    </li>
+
+    <li><a href="leadership.html">Leadership</a></li>
+    <li><a href="contact.html">Contact</a></li>
+  </ul>
+</nav>
   </aside>
 
   <!-- ===== HERO ===== -->

--- a/practicetools.html
+++ b/practicetools.html
@@ -222,46 +222,47 @@
         <img src="NYU_Short_RGB_White.png" alt="NYU Logo" class="logo-nyu" />
       </div>
 
-            <nav class="nav-links" aria-label="Primary">
-        <ul class="menu-root">
-          <li><a href="index.html">Home</a></li>
+            
+<nav class="nav-links" aria-label="Primary">
+  <ul class="menu-root">
+    <li><a href="index.html">Home</a></li>
+    <li><a href="members.html">Members</a></li>
 
-          <li class="has-submenu">
-            <a href="about.html" class="top-link" aria-haspopup="true" aria-expanded="false">About</a>
-            <ul class="submenu" role="menu" aria-label="About submenu">
-              <li role="none"><a role="menuitem" href="about.html#who-we-are">Who We Are</a></li>
-              <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
-              <li role="none"><a role="menuitem" href="about.html#meetings">Meetings & Attendance</a></li>
-              <li role="none"><a role="menuitem" href="equity.html">Equity Policy</a></li>
-              <li role="none"><a role="menuitem" href="why-pdu.html">Why PDU</a></li>
-            </ul>
-          </li>
+    <li class="has-submenu">
+      <a href="about.html" class="top-link" aria-haspopup="true" aria-expanded="false">About</a>
+      <ul class="submenu" role="menu" aria-label="About submenu">
+        <li role="none"><a role="menuitem" href="about.html#who-we-are">Who We Are</a></li>
+        <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
+        <li role="none"><a role="menuitem" href="about.html#meetings">Meetings & Attendance</a></li>
+        <li role="none"><a role="menuitem" href="equity.html">Equity Policy</a></li>
+        <li role="none"><a role="menuitem" href="why-pdu.html">Why PDU</a></li>
+      </ul>
+    </li>
 
-          <li class="has-submenu">
-            <a href="tournaments.html" class="top-link" aria-haspopup="true" aria-expanded="false">Tournaments</a>
-            <ul class="submenu" role="menu" aria-label="Tournaments submenu">
-              <li role="none"><a role="menuitem" href="tournaments.html#featured">Next Tournament</a></li>
-              <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
-            </ul>
-          </li>
+    <li class="has-submenu">
+      <a href="tournaments.html" class="top-link" aria-haspopup="true" aria-expanded="false">Tournaments</a>
+      <ul class="submenu" role="menu" aria-label="Tournaments submenu">
+        <li role="none"><a role="menuitem" href="tournaments.html#featured">Next Tournament</a></li>
+        <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
+      </ul>
+    </li>
 
-          <li class="has-submenu">
-            <a href="join.html" class="top-link" aria-haspopup="true" aria-expanded="false">Join Us</a>
-            <ul class="submenu" role="menu" aria-label="Join Us submenu">
-              <li role="none"><a role="menuitem" href="join.html#mailing">Mailing List</a></li>
-              <li role="none"><a role="menuitem" href="join.html#meetings">Meetings</a></li>
-              <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
-              <li role="none"><a role="menuitem" href="practicetools.html" aria-current="page">Practice Tools</a></li>
-              <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
-              <li role="none"><a role="menuitem" href="resources.html">Resources Library</a></li>
-            </ul>
-          </li>
+    <li class="has-submenu">
+      <a href="join.html" class="top-link join-link" aria-haspopup="true" aria-expanded="false">Join Us</a>
+      <ul class="submenu" role="menu" aria-label="Join Us submenu">
+        <li role="none"><a role="menuitem" href="join.html#mailing">Mailing List</a></li>
+        <li role="none"><a role="menuitem" href="join.html#meetings">Meetings</a></li>
+        <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
+        <li role="none"><a role="menuitem" href="practicetools.html" aria-current="page">Practice Tools</a></li>
+        <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
+        <li role="none"><a role="menuitem" href="resources.html">Resources Library</a></li>
+      </ul>
+    </li>
 
-          <li><a href="leadership.html">Leadership</a></li>
-          <li><a href="members.html">Members</a></li>
-          <li><a href="contact.html">Contact</a></li>
-        </ul>
-      </nav>
+    <li><a href="leadership.html">Leadership</a></li>
+    <li><a href="contact.html">Contact</a></li>
+  </ul>
+</nav>
 
       <div class="nav-left">
         <a href="index.html" aria-label="Home" class="brand-link">
@@ -281,47 +282,48 @@
       <span>Menu</span>
       <button id="drawerClose" class="drawer-close" aria-label="Close menu">×</button>
     </div>
-        <nav class="drawer-nav" aria-label="Mobile">
-      <ul class="drawer-list">
-        <li><a href="index.html">Home</a></li>
+        
+<nav class="drawer-nav" aria-label="Mobile">
+  <ul class="drawer-list">
+    <li><a href="index.html">Home</a></li>
+    <li><a href="members.html">Members</a></li>
 
-        <li class="drawer-group">
-          <button class="drawer-toggle" aria-expanded="false">About</button>
-          <ul class="drawer-submenu">
-            <li><a href="about.html#who-we-are">Who We Are</a></li>
-            <li><a href="beginner.html">Beginners Guide</a></li>
-            <li><a href="about.html#meetings">Meetings & Attendance</a></li>
-            <li><a href="equity.html">Equity Policy</a></li>
-            <li><a href="why-pdu.html">Why PDU</a></li>
-          </ul>
-        </li>
-
-        <li class="drawer-group">
-          <button class="drawer-toggle" aria-expanded="false">Tournaments</button>
-          <ul class="drawer-submenu">
-            <li><a href="tournaments.html#featured">Next Tournament</a></li>
-            <li><a href="tournaments.html">Upcoming</a></li>
-            <li><a href="calendar.html">Calendar</a></li>
-          </ul>
-        </li>
-
-        <li class="drawer-group">
-          <button class="drawer-toggle" aria-expanded="false">Join Us</button>
-          <ul class="drawer-submenu">
-            <li><a href="join.html#mailing">Mailing List</a></li>
-            <li><a href="join.html#meetings">Meetings</a></li>
-            <li><a href="beginner.html">Beginners Guide</a></li>
-            <li><a href="practicetools.html">Practice Tools</a></li>
-            <li><a href="calendar.html">Calendar</a></li>
-            <li><a href="resources.html">Resources Library</a></li>
-          </ul>
-        </li>
-
-        <li><a href="leadership.html">Leadership</a></li>
-        <li><a href="members.html">Members</a></li>
-        <li><a href="contact.html">Contact</a></li>
+    <li class="drawer-group">
+      <button class="drawer-toggle" aria-expanded="false">About</button>
+      <ul class="drawer-submenu">
+        <li><a href="about.html#who-we-are">Who We Are</a></li>
+        <li><a href="beginner.html">Beginners Guide</a></li>
+        <li><a href="about.html#meetings">Meetings & Attendance</a></li>
+        <li><a href="equity.html">Equity Policy</a></li>
+        <li><a href="why-pdu.html">Why PDU</a></li>
       </ul>
-    </nav>
+    </li>
+
+    <li class="drawer-group">
+      <button class="drawer-toggle" aria-expanded="false">Tournaments</button>
+      <ul class="drawer-submenu">
+        <li><a href="tournaments.html#featured">Next Tournament</a></li>
+        <li><a href="tournaments.html">Upcoming</a></li>
+        <li><a href="calendar.html">Calendar</a></li>
+      </ul>
+    </li>
+
+    <li class="drawer-group">
+      <button class="drawer-toggle join-link" aria-expanded="false">Join Us</button>
+      <ul class="drawer-submenu">
+        <li><a href="join.html#mailing">Mailing List</a></li>
+        <li><a href="join.html#meetings">Meetings</a></li>
+        <li><a href="beginner.html">Beginners Guide</a></li>
+        <li><a href="practicetools.html" aria-current="page">Practice Tools</a></li>
+        <li><a href="calendar.html">Calendar</a></li>
+        <li><a href="resources.html">Resources Library</a></li>
+      </ul>
+    </li>
+
+    <li><a href="leadership.html">Leadership</a></li>
+    <li><a href="contact.html">Contact</a></li>
+  </ul>
+</nav>
   </aside>
 
   <!-- ====================== HERO ====================== -->

--- a/resources.html
+++ b/resources.html
@@ -148,46 +148,47 @@
         <img src="NYU_Short_RGB_White.png" alt="NYU Logo" class="logo-nyu" />
       </div>
 
-            <nav class="nav-links" aria-label="Primary">
-        <ul class="menu-root">
-          <li><a href="index.html">Home</a></li>
+            
+<nav class="nav-links" aria-label="Primary">
+  <ul class="menu-root">
+    <li><a href="index.html">Home</a></li>
+    <li><a href="members.html">Members</a></li>
 
-          <li class="has-submenu">
-            <a href="about.html" class="top-link" aria-haspopup="true" aria-expanded="false">About</a>
-            <ul class="submenu" role="menu" aria-label="About submenu">
-              <li role="none"><a role="menuitem" href="about.html#who-we-are">Who We Are</a></li>
-              <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
-              <li role="none"><a role="menuitem" href="about.html#meetings">Meetings & Attendance</a></li>
-              <li role="none"><a role="menuitem" href="equity.html">Equity Policy</a></li>
-              <li role="none"><a role="menuitem" href="why-pdu.html">Why PDU</a></li>
-            </ul>
-          </li>
+    <li class="has-submenu">
+      <a href="about.html" class="top-link" aria-haspopup="true" aria-expanded="false">About</a>
+      <ul class="submenu" role="menu" aria-label="About submenu">
+        <li role="none"><a role="menuitem" href="about.html#who-we-are">Who We Are</a></li>
+        <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
+        <li role="none"><a role="menuitem" href="about.html#meetings">Meetings & Attendance</a></li>
+        <li role="none"><a role="menuitem" href="equity.html">Equity Policy</a></li>
+        <li role="none"><a role="menuitem" href="why-pdu.html">Why PDU</a></li>
+      </ul>
+    </li>
 
-          <li class="has-submenu">
-            <a href="tournaments.html" class="top-link" aria-haspopup="true" aria-expanded="false">Tournaments</a>
-            <ul class="submenu" role="menu" aria-label="Tournaments submenu">
-              <li role="none"><a role="menuitem" href="tournaments.html#featured">Next Tournament</a></li>
-              <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
-            </ul>
-          </li>
+    <li class="has-submenu">
+      <a href="tournaments.html" class="top-link" aria-haspopup="true" aria-expanded="false">Tournaments</a>
+      <ul class="submenu" role="menu" aria-label="Tournaments submenu">
+        <li role="none"><a role="menuitem" href="tournaments.html#featured">Next Tournament</a></li>
+        <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
+      </ul>
+    </li>
 
-          <li class="has-submenu">
-            <a href="join.html" class="top-link" aria-haspopup="true" aria-expanded="false">Join Us</a>
-            <ul class="submenu" role="menu" aria-label="Join Us submenu">
-              <li role="none"><a role="menuitem" href="join.html#mailing">Mailing List</a></li>
-              <li role="none"><a role="menuitem" href="join.html#meetings">Meetings</a></li>
-              <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
-              <li role="none"><a role="menuitem" href="practicetools.html">Practice Tools</a></li>
-              <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
-              <li role="none"><a role="menuitem" href="resources.html" aria-current="page">Resources Library</a></li>
-            </ul>
-          </li>
+    <li class="has-submenu">
+      <a href="join.html" class="top-link join-link" aria-haspopup="true" aria-expanded="false">Join Us</a>
+      <ul class="submenu" role="menu" aria-label="Join Us submenu">
+        <li role="none"><a role="menuitem" href="join.html#mailing">Mailing List</a></li>
+        <li role="none"><a role="menuitem" href="join.html#meetings">Meetings</a></li>
+        <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
+        <li role="none"><a role="menuitem" href="practicetools.html">Practice Tools</a></li>
+        <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
+        <li role="none"><a role="menuitem" href="resources.html" aria-current="page">Resources Library</a></li>
+      </ul>
+    </li>
 
-          <li><a href="leadership.html">Leadership</a></li>
-          <li><a href="members.html">Members</a></li>
-          <li><a href="contact.html">Contact</a></li>
-        </ul>
-      </nav>
+    <li><a href="leadership.html">Leadership</a></li>
+    <li><a href="contact.html">Contact</a></li>
+  </ul>
+</nav>
 
       <div class="nav-left">
         <a href="index.html" aria-label="Home" class="brand-link">
@@ -207,47 +208,48 @@
       <span>Menu</span>
       <button id="drawerClose" class="drawer-close" aria-label="Close menu">×</button>
     </div>
-        <nav class="drawer-nav" aria-label="Mobile">
-      <ul class="drawer-list">
-        <li><a href="index.html">Home</a></li>
+        
+<nav class="drawer-nav" aria-label="Mobile">
+  <ul class="drawer-list">
+    <li><a href="index.html">Home</a></li>
+    <li><a href="members.html">Members</a></li>
 
-        <li class="drawer-group">
-          <button class="drawer-toggle" aria-expanded="false">About</button>
-          <ul class="drawer-submenu">
-            <li><a href="about.html#who-we-are">Who We Are</a></li>
-            <li><a href="beginner.html">Beginners Guide</a></li>
-            <li><a href="about.html#meetings">Meetings & Attendance</a></li>
-            <li><a href="equity.html">Equity Policy</a></li>
-            <li><a href="why-pdu.html">Why PDU</a></li>
-          </ul>
-        </li>
-
-        <li class="drawer-group">
-          <button class="drawer-toggle" aria-expanded="false">Tournaments</button>
-          <ul class="drawer-submenu">
-            <li><a href="tournaments.html#featured">Next Tournament</a></li>
-            <li><a href="tournaments.html">Upcoming</a></li>
-            <li><a href="calendar.html">Calendar</a></li>
-          </ul>
-        </li>
-
-        <li class="drawer-group">
-          <button class="drawer-toggle" aria-expanded="false">Join Us</button>
-          <ul class="drawer-submenu">
-            <li><a href="join.html#mailing">Mailing List</a></li>
-            <li><a href="join.html#meetings">Meetings</a></li>
-            <li><a href="beginner.html">Beginners Guide</a></li>
-            <li><a href="practicetools.html">Practice Tools</a></li>
-            <li><a href="calendar.html">Calendar</a></li>
-            <li><a href="resources.html">Resources Library</a></li>
-          </ul>
-        </li>
-
-        <li><a href="leadership.html">Leadership</a></li>
-        <li><a href="members.html">Members</a></li>
-        <li><a href="contact.html">Contact</a></li>
+    <li class="drawer-group">
+      <button class="drawer-toggle" aria-expanded="false">About</button>
+      <ul class="drawer-submenu">
+        <li><a href="about.html#who-we-are">Who We Are</a></li>
+        <li><a href="beginner.html">Beginners Guide</a></li>
+        <li><a href="about.html#meetings">Meetings & Attendance</a></li>
+        <li><a href="equity.html">Equity Policy</a></li>
+        <li><a href="why-pdu.html">Why PDU</a></li>
       </ul>
-    </nav>
+    </li>
+
+    <li class="drawer-group">
+      <button class="drawer-toggle" aria-expanded="false">Tournaments</button>
+      <ul class="drawer-submenu">
+        <li><a href="tournaments.html#featured">Next Tournament</a></li>
+        <li><a href="tournaments.html">Upcoming</a></li>
+        <li><a href="calendar.html">Calendar</a></li>
+      </ul>
+    </li>
+
+    <li class="drawer-group">
+      <button class="drawer-toggle join-link" aria-expanded="false">Join Us</button>
+      <ul class="drawer-submenu">
+        <li><a href="join.html#mailing">Mailing List</a></li>
+        <li><a href="join.html#meetings">Meetings</a></li>
+        <li><a href="beginner.html">Beginners Guide</a></li>
+        <li><a href="practicetools.html">Practice Tools</a></li>
+        <li><a href="calendar.html">Calendar</a></li>
+        <li><a href="resources.html" aria-current="page">Resources Library</a></li>
+      </ul>
+    </li>
+
+    <li><a href="leadership.html">Leadership</a></li>
+    <li><a href="contact.html">Contact</a></li>
+  </ul>
+</nav>
   </aside>
 
   <!-- ====================== HERO ====================== -->

--- a/style.css
+++ b/style.css
@@ -164,7 +164,7 @@ nav a:hover{ color:#fff; text-shadow:0 0 8px rgba(199,191,255,.9); }
 }
 .drawer-nav{ padding:.5rem .5rem 1rem; }
 .drawer-list{ list-style:none; }
-.drawer-list > li{ margin:.35rem 0; }
+.drawer-list > li{ margin:.65rem 0; }
 .drawer-list>li>a,.drawer-toggle{
   width:100%; text-align:left; padding:.75rem .85rem;
   background:transparent; color:#fff; border:1px solid transparent;
@@ -429,3 +429,7 @@ section[id] .about-header, section[id] h3, section[id] h4{ scroll-margin-top:96p
   .hero-title{ font-size:2.1rem; }
   .week-strip{ margin-top:-26px; }
 }
+
+/* Highlight Join Us link */
+.join-link{ color:#ffd700; text-shadow:0 0 8px rgba(255,215,0,.8); }
+.drawer-list .join-link{ color:#ffd700; text-shadow:0 0 8px rgba(255,215,0,.8); }

--- a/tournaments.html
+++ b/tournaments.html
@@ -96,46 +96,47 @@
         <img src="NYU_Short_RGB_White.png" alt="NYU Logo" class="logo-nyu" />
       </div>
 
-            <nav class="nav-links" aria-label="Primary">
-        <ul class="menu-root">
-          <li><a href="index.html">Home</a></li>
+            
+<nav class="nav-links" aria-label="Primary">
+  <ul class="menu-root">
+    <li><a href="index.html">Home</a></li>
+    <li><a href="members.html">Members</a></li>
 
-          <li class="has-submenu">
-            <a href="about.html" class="top-link" aria-haspopup="true" aria-expanded="false">About</a>
-            <ul class="submenu" role="menu" aria-label="About submenu">
-              <li role="none"><a role="menuitem" href="about.html#who-we-are">Who We Are</a></li>
-              <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
-              <li role="none"><a role="menuitem" href="about.html#meetings">Meetings & Attendance</a></li>
-              <li role="none"><a role="menuitem" href="equity.html">Equity Policy</a></li>
-              <li role="none"><a role="menuitem" href="why-pdu.html">Why PDU</a></li>
-            </ul>
-          </li>
+    <li class="has-submenu">
+      <a href="about.html" class="top-link" aria-haspopup="true" aria-expanded="false">About</a>
+      <ul class="submenu" role="menu" aria-label="About submenu">
+        <li role="none"><a role="menuitem" href="about.html#who-we-are">Who We Are</a></li>
+        <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
+        <li role="none"><a role="menuitem" href="about.html#meetings">Meetings & Attendance</a></li>
+        <li role="none"><a role="menuitem" href="equity.html">Equity Policy</a></li>
+        <li role="none"><a role="menuitem" href="why-pdu.html">Why PDU</a></li>
+      </ul>
+    </li>
 
-          <li class="has-submenu">
-            <a href="tournaments.html" class="top-link" aria-haspopup="true" aria-expanded="false" aria-current="page">Tournaments</a>
-            <ul class="submenu" role="menu" aria-label="Tournaments submenu">
-              <li role="none"><a role="menuitem" href="tournaments.html#featured">Next Tournament</a></li>
-              <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
-            </ul>
-          </li>
+    <li class="has-submenu">
+      <a href="tournaments.html" class="top-link" aria-current="page" aria-haspopup="true" aria-expanded="false">Tournaments</a>
+      <ul class="submenu" role="menu" aria-label="Tournaments submenu">
+        <li role="none"><a role="menuitem" href="tournaments.html#featured">Next Tournament</a></li>
+        <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
+      </ul>
+    </li>
 
-          <li class="has-submenu">
-            <a href="join.html" class="top-link" aria-haspopup="true" aria-expanded="false">Join Us</a>
-            <ul class="submenu" role="menu" aria-label="Join Us submenu">
-              <li role="none"><a role="menuitem" href="join.html#mailing">Mailing List</a></li>
-              <li role="none"><a role="menuitem" href="join.html#meetings">Meetings</a></li>
-              <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
-              <li role="none"><a role="menuitem" href="practicetools.html">Practice Tools</a></li>
-              <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
-              <li role="none"><a role="menuitem" href="resources.html">Resources Library</a></li>
-            </ul>
-          </li>
+    <li class="has-submenu">
+      <a href="join.html" class="top-link join-link" aria-haspopup="true" aria-expanded="false">Join Us</a>
+      <ul class="submenu" role="menu" aria-label="Join Us submenu">
+        <li role="none"><a role="menuitem" href="join.html#mailing">Mailing List</a></li>
+        <li role="none"><a role="menuitem" href="join.html#meetings">Meetings</a></li>
+        <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
+        <li role="none"><a role="menuitem" href="practicetools.html">Practice Tools</a></li>
+        <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
+        <li role="none"><a role="menuitem" href="resources.html">Resources Library</a></li>
+      </ul>
+    </li>
 
-          <li><a href="leadership.html">Leadership</a></li>
-          <li><a href="members.html">Members</a></li>
-          <li><a href="contact.html">Contact</a></li>
-        </ul>
-      </nav>
+    <li><a href="leadership.html">Leadership</a></li>
+    <li><a href="contact.html">Contact</a></li>
+  </ul>
+</nav>
 
       <div class="nav-left">
         <a href="index.html" aria-label="Home" class="brand-link">
@@ -155,47 +156,48 @@
       <span>Menu</span>
       <button id="drawerClose" class="drawer-close" aria-label="Close menu">×</button>
     </div>
-        <nav class="drawer-nav" aria-label="Mobile">
-      <ul class="drawer-list">
-        <li><a href="index.html">Home</a></li>
+        
+<nav class="drawer-nav" aria-label="Mobile">
+  <ul class="drawer-list">
+    <li><a href="index.html">Home</a></li>
+    <li><a href="members.html">Members</a></li>
 
-        <li class="drawer-group">
-          <button class="drawer-toggle" aria-expanded="false">About</button>
-          <ul class="drawer-submenu">
-            <li><a href="about.html#who-we-are">Who We Are</a></li>
-            <li><a href="beginner.html">Beginners Guide</a></li>
-            <li><a href="about.html#meetings">Meetings & Attendance</a></li>
-            <li><a href="equity.html">Equity Policy</a></li>
-            <li><a href="why-pdu.html">Why PDU</a></li>
-          </ul>
-        </li>
-
-        <li class="drawer-group">
-          <button class="drawer-toggle" aria-expanded="false">Tournaments</button>
-          <ul class="drawer-submenu">
-            <li><a href="tournaments.html#featured">Next Tournament</a></li>
-            <li><a href="tournaments.html">Upcoming</a></li>
-            <li><a href="calendar.html">Calendar</a></li>
-          </ul>
-        </li>
-
-        <li class="drawer-group">
-          <button class="drawer-toggle" aria-expanded="false">Join Us</button>
-          <ul class="drawer-submenu">
-            <li><a href="join.html#mailing">Mailing List</a></li>
-            <li><a href="join.html#meetings">Meetings</a></li>
-            <li><a href="beginner.html">Beginners Guide</a></li>
-            <li><a href="practicetools.html">Practice Tools</a></li>
-            <li><a href="calendar.html">Calendar</a></li>
-            <li><a href="resources.html">Resources Library</a></li>
-          </ul>
-        </li>
-
-        <li><a href="leadership.html">Leadership</a></li>
-        <li><a href="members.html">Members</a></li>
-        <li><a href="contact.html">Contact</a></li>
+    <li class="drawer-group">
+      <button class="drawer-toggle" aria-expanded="false">About</button>
+      <ul class="drawer-submenu">
+        <li><a href="about.html#who-we-are">Who We Are</a></li>
+        <li><a href="beginner.html">Beginners Guide</a></li>
+        <li><a href="about.html#meetings">Meetings & Attendance</a></li>
+        <li><a href="equity.html">Equity Policy</a></li>
+        <li><a href="why-pdu.html">Why PDU</a></li>
       </ul>
-    </nav>
+    </li>
+
+    <li class="drawer-group">
+      <button class="drawer-toggle" aria-expanded="false" aria-current="page">Tournaments</button>
+      <ul class="drawer-submenu">
+        <li><a href="tournaments.html#featured">Next Tournament</a></li>
+        <li><a href="tournaments.html">Upcoming</a></li>
+        <li><a href="calendar.html">Calendar</a></li>
+      </ul>
+    </li>
+
+    <li class="drawer-group">
+      <button class="drawer-toggle join-link" aria-expanded="false">Join Us</button>
+      <ul class="drawer-submenu">
+        <li><a href="join.html#mailing">Mailing List</a></li>
+        <li><a href="join.html#meetings">Meetings</a></li>
+        <li><a href="beginner.html">Beginners Guide</a></li>
+        <li><a href="practicetools.html">Practice Tools</a></li>
+        <li><a href="calendar.html">Calendar</a></li>
+        <li><a href="resources.html">Resources Library</a></li>
+      </ul>
+    </li>
+
+    <li><a href="leadership.html">Leadership</a></li>
+    <li><a href="contact.html">Contact</a></li>
+  </ul>
+</nav>
   </aside>
 
   <!-- Hero -->


### PR DESCRIPTION
## Summary
- Reordered navigation so Members precedes About on every page
- Added glow styling to the Join Us link and unified dropdown menus across pages
- Increased spacing between items in the mobile drawer for better tap targets

## Testing
- `npx --yes htmlhint about.html leadership.html resources.html members.html practicetools.html join.html contact.html beginner.html judging.html calendar.html tournaments.html equity.html index.html advanced.html`

------
https://chatgpt.com/codex/tasks/task_e_68b0ddfe64cc832293fecdc991f16d66