### PR TITLE
Reorder navigation links across site

### DIFF
--- a/about.html
+++ b/about.html
@@ -33,18 +33,6 @@
   <ul class="menu-root">
     <li><a href="index.html">Home</a></li>
     <li><a href="members.html">Members</a></li>
-
-    <li class="has-submenu">
-      <a href="about.html" class="top-link" aria-current="page" aria-haspopup="true" aria-expanded="false">About</a>
-      <ul class="submenu" role="menu" aria-label="About submenu">
-        <li role="none"><a role="menuitem" href="about.html#who-we-are">Who We Are</a></li>
-        <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
-        <li role="none"><a role="menuitem" href="about.html#meetings">Meetings & Attendance</a></li>
-        <li role="none"><a role="menuitem" href="equity.html">Equity Policy</a></li>
-        <li role="none"><a role="menuitem" href="why-pdu.html">Why PDU</a></li>
-      </ul>
-    </li>
-
     <li class="has-submenu">
       <a href="tournaments.html" class="top-link" aria-haspopup="true" aria-expanded="false">Tournaments</a>
       <ul class="submenu" role="menu" aria-label="Tournaments submenu">
@@ -62,6 +50,18 @@
         <li role="none"><a role="menuitem" href="practicetools.html">Practice Tools</a></li>
         <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
         <li role="none"><a role="menuitem" href="resources.html">Resources Library</a></li>
+      </ul>
+    </li>
+
+
+    <li class="has-submenu">
+      <a href="about.html" class="top-link" aria-current="page" aria-haspopup="true" aria-expanded="false">About Us</a>
+      <ul class="submenu" role="menu" aria-label="About Us submenu">
+        <li role="none"><a role="menuitem" href="about.html#who-we-are">Who We Are</a></li>
+        <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
+        <li role="none"><a role="menuitem" href="about.html#meetings">Meetings & Attendance</a></li>
+        <li role="none"><a role="menuitem" href="equity.html">Equity Policy</a></li>
+        <li role="none"><a role="menuitem" href="why-pdu.html">Why PDU</a></li>
       </ul>
     </li>
 
@@ -95,18 +95,6 @@
   <ul class="drawer-list">
     <li><a href="index.html">Home</a></li>
     <li><a href="members.html">Members</a></li>
-
-    <li class="drawer-group">
-      <button class="drawer-toggle" aria-expanded="false" aria-current="page">About</button>
-      <ul class="drawer-submenu">
-        <li><a href="about.html#who-we-are">Who We Are</a></li>
-        <li><a href="beginner.html">Beginners Guide</a></li>
-        <li><a href="about.html#meetings">Meetings & Attendance</a></li>
-        <li><a href="equity.html">Equity Policy</a></li>
-        <li><a href="why-pdu.html">Why PDU</a></li>
-      </ul>
-    </li>
-
     <li class="drawer-group">
       <button class="drawer-toggle" aria-expanded="false">Tournaments</button>
       <ul class="drawer-submenu">
@@ -125,6 +113,18 @@
         <li><a href="practicetools.html">Practice Tools</a></li>
         <li><a href="calendar.html">Calendar</a></li>
         <li><a href="resources.html">Resources Library</a></li>
+      </ul>
+    </li>
+
+
+    <li class="drawer-group">
+      <button class="drawer-toggle" aria-expanded="false" aria-current="page">About Us</button>
+      <ul class="drawer-submenu">
+        <li><a href="about.html#who-we-are">Who We Are</a></li>
+        <li><a href="beginner.html">Beginners Guide</a></li>
+        <li><a href="about.html#meetings">Meetings & Attendance</a></li>
+        <li><a href="equity.html">Equity Policy</a></li>
+        <li><a href="why-pdu.html">Why PDU</a></li>
       </ul>
     </li>
 

--- a/advanced.html
+++ b/advanced.html
@@ -121,18 +121,6 @@
   <ul class="menu-root">
     <li><a href="index.html">Home</a></li>
     <li><a href="members.html">Members</a></li>
-
-    <li class="has-submenu">
-      <a href="about.html" class="top-link" aria-haspopup="true" aria-expanded="false">About</a>
-      <ul class="submenu" role="menu" aria-label="About submenu">
-        <li role="none"><a role="menuitem" href="about.html#who-we-are">Who We Are</a></li>
-        <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
-        <li role="none"><a role="menuitem" href="about.html#meetings">Meetings & Attendance</a></li>
-        <li role="none"><a role="menuitem" href="equity.html">Equity Policy</a></li>
-        <li role="none"><a role="menuitem" href="why-pdu.html">Why PDU</a></li>
-      </ul>
-    </li>
-
     <li class="has-submenu">
       <a href="tournaments.html" class="top-link" aria-haspopup="true" aria-expanded="false">Tournaments</a>
       <ul class="submenu" role="menu" aria-label="Tournaments submenu">
@@ -150,6 +138,18 @@
         <li role="none"><a role="menuitem" href="practicetools.html">Practice Tools</a></li>
         <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
         <li role="none"><a role="menuitem" href="resources.html">Resources Library</a></li>
+      </ul>
+    </li>
+
+
+    <li class="has-submenu">
+      <a href="about.html" class="top-link" aria-haspopup="true" aria-expanded="false">About Us</a>
+      <ul class="submenu" role="menu" aria-label="About Us submenu">
+        <li role="none"><a role="menuitem" href="about.html#who-we-are">Who We Are</a></li>
+        <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
+        <li role="none"><a role="menuitem" href="about.html#meetings">Meetings & Attendance</a></li>
+        <li role="none"><a role="menuitem" href="equity.html">Equity Policy</a></li>
+        <li role="none"><a role="menuitem" href="why-pdu.html">Why PDU</a></li>
       </ul>
     </li>
 
@@ -182,18 +182,6 @@
   <ul class="drawer-list">
     <li><a href="index.html">Home</a></li>
     <li><a href="members.html">Members</a></li>
-
-    <li class="drawer-group">
-      <button class="drawer-toggle" aria-expanded="false">About</button>
-      <ul class="drawer-submenu">
-        <li><a href="about.html#who-we-are">Who We Are</a></li>
-        <li><a href="beginner.html">Beginners Guide</a></li>
-        <li><a href="about.html#meetings">Meetings & Attendance</a></li>
-        <li><a href="equity.html">Equity Policy</a></li>
-        <li><a href="why-pdu.html">Why PDU</a></li>
-      </ul>
-    </li>
-
     <li class="drawer-group">
       <button class="drawer-toggle" aria-expanded="false">Tournaments</button>
       <ul class="drawer-submenu">
@@ -212,6 +200,18 @@
         <li><a href="practicetools.html">Practice Tools</a></li>
         <li><a href="calendar.html">Calendar</a></li>
         <li><a href="resources.html">Resources Library</a></li>
+      </ul>
+    </li>
+
+
+    <li class="drawer-group">
+      <button class="drawer-toggle" aria-expanded="false">About Us</button>
+      <ul class="drawer-submenu">
+        <li><a href="about.html#who-we-are">Who We Are</a></li>
+        <li><a href="beginner.html">Beginners Guide</a></li>
+        <li><a href="about.html#meetings">Meetings & Attendance</a></li>
+        <li><a href="equity.html">Equity Policy</a></li>
+        <li><a href="why-pdu.html">Why PDU</a></li>
       </ul>
     </li>
 

--- a/beginner.html
+++ b/beginner.html
@@ -162,18 +162,6 @@
   <ul class="menu-root">
     <li><a href="index.html">Home</a></li>
     <li><a href="members.html">Members</a></li>
-
-    <li class="has-submenu">
-      <a href="about.html" class="top-link" aria-haspopup="true" aria-expanded="false">About</a>
-      <ul class="submenu" role="menu" aria-label="About submenu">
-        <li role="none"><a role="menuitem" href="about.html#who-we-are">Who We Are</a></li>
-        <li role="none"><a role="menuitem" href="beginner.html" aria-current="page">Beginners Guide</a></li>
-        <li role="none"><a role="menuitem" href="about.html#meetings">Meetings & Attendance</a></li>
-        <li role="none"><a role="menuitem" href="equity.html">Equity Policy</a></li>
-        <li role="none"><a role="menuitem" href="why-pdu.html">Why PDU</a></li>
-      </ul>
-    </li>
-
     <li class="has-submenu">
       <a href="tournaments.html" class="top-link" aria-haspopup="true" aria-expanded="false">Tournaments</a>
       <ul class="submenu" role="menu" aria-label="Tournaments submenu">
@@ -191,6 +179,18 @@
         <li role="none"><a role="menuitem" href="practicetools.html">Practice Tools</a></li>
         <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
         <li role="none"><a role="menuitem" href="resources.html">Resources Library</a></li>
+      </ul>
+    </li>
+
+
+    <li class="has-submenu">
+      <a href="about.html" class="top-link" aria-haspopup="true" aria-expanded="false">About Us</a>
+      <ul class="submenu" role="menu" aria-label="About Us submenu">
+        <li role="none"><a role="menuitem" href="about.html#who-we-are">Who We Are</a></li>
+        <li role="none"><a role="menuitem" href="beginner.html" aria-current="page">Beginners Guide</a></li>
+        <li role="none"><a role="menuitem" href="about.html#meetings">Meetings & Attendance</a></li>
+        <li role="none"><a role="menuitem" href="equity.html">Equity Policy</a></li>
+        <li role="none"><a role="menuitem" href="why-pdu.html">Why PDU</a></li>
       </ul>
     </li>
 
@@ -222,18 +222,6 @@
   <ul class="drawer-list">
     <li><a href="index.html">Home</a></li>
     <li><a href="members.html">Members</a></li>
-
-    <li class="drawer-group">
-      <button class="drawer-toggle" aria-expanded="false">About</button>
-      <ul class="drawer-submenu">
-        <li><a href="about.html#who-we-are">Who We Are</a></li>
-        <li><a href="beginner.html" aria-current="page">Beginners Guide</a></li>
-        <li><a href="about.html#meetings">Meetings & Attendance</a></li>
-        <li><a href="equity.html">Equity Policy</a></li>
-        <li><a href="why-pdu.html">Why PDU</a></li>
-      </ul>
-    </li>
-
     <li class="drawer-group">
       <button class="drawer-toggle" aria-expanded="false">Tournaments</button>
       <ul class="drawer-submenu">
@@ -252,6 +240,18 @@
         <li><a href="practicetools.html">Practice Tools</a></li>
         <li><a href="calendar.html">Calendar</a></li>
         <li><a href="resources.html">Resources Library</a></li>
+      </ul>
+    </li>
+
+
+    <li class="drawer-group">
+      <button class="drawer-toggle" aria-expanded="false">About Us</button>
+      <ul class="drawer-submenu">
+        <li><a href="about.html#who-we-are">Who We Are</a></li>
+        <li><a href="beginner.html" aria-current="page">Beginners Guide</a></li>
+        <li><a href="about.html#meetings">Meetings & Attendance</a></li>
+        <li><a href="equity.html">Equity Policy</a></li>
+        <li><a href="why-pdu.html">Why PDU</a></li>
       </ul>
     </li>
 

--- a/calendar.html
+++ b/calendar.html
@@ -38,18 +38,6 @@
   <ul class="menu-root">
     <li><a href="index.html">Home</a></li>
     <li><a href="members.html">Members</a></li>
-
-    <li class="has-submenu">
-      <a href="about.html" class="top-link" aria-haspopup="true" aria-expanded="false">About</a>
-      <ul class="submenu" role="menu" aria-label="About submenu">
-        <li role="none"><a role="menuitem" href="about.html#who-we-are">Who We Are</a></li>
-        <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
-        <li role="none"><a role="menuitem" href="about.html#meetings">Meetings & Attendance</a></li>
-        <li role="none"><a role="menuitem" href="equity.html">Equity Policy</a></li>
-        <li role="none"><a role="menuitem" href="why-pdu.html">Why PDU</a></li>
-      </ul>
-    </li>
-
     <li class="has-submenu">
       <a href="tournaments.html" class="top-link" aria-haspopup="true" aria-expanded="false">Tournaments</a>
       <ul class="submenu" role="menu" aria-label="Tournaments submenu">
@@ -67,6 +55,18 @@
         <li role="none"><a role="menuitem" href="practicetools.html">Practice Tools</a></li>
         <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
         <li role="none"><a role="menuitem" href="resources.html">Resources Library</a></li>
+      </ul>
+    </li>
+
+
+    <li class="has-submenu">
+      <a href="about.html" class="top-link" aria-haspopup="true" aria-expanded="false">About Us</a>
+      <ul class="submenu" role="menu" aria-label="About Us submenu">
+        <li role="none"><a role="menuitem" href="about.html#who-we-are">Who We Are</a></li>
+        <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
+        <li role="none"><a role="menuitem" href="about.html#meetings">Meetings & Attendance</a></li>
+        <li role="none"><a role="menuitem" href="equity.html">Equity Policy</a></li>
+        <li role="none"><a role="menuitem" href="why-pdu.html">Why PDU</a></li>
       </ul>
     </li>
 
@@ -96,18 +96,6 @@
   <ul class="drawer-list">
     <li><a href="index.html">Home</a></li>
     <li><a href="members.html">Members</a></li>
-
-    <li class="drawer-group">
-      <button class="drawer-toggle" aria-expanded="false">About</button>
-      <ul class="drawer-submenu">
-        <li><a href="about.html#who-we-are">Who We Are</a></li>
-        <li><a href="beginner.html">Beginners Guide</a></li>
-        <li><a href="about.html#meetings">Meetings & Attendance</a></li>
-        <li><a href="equity.html">Equity Policy</a></li>
-        <li><a href="why-pdu.html">Why PDU</a></li>
-      </ul>
-    </li>
-
     <li class="drawer-group">
       <button class="drawer-toggle" aria-expanded="false">Tournaments</button>
       <ul class="drawer-submenu">
@@ -126,6 +114,18 @@
         <li><a href="practicetools.html">Practice Tools</a></li>
         <li><a href="calendar.html">Calendar</a></li>
         <li><a href="resources.html">Resources Library</a></li>
+      </ul>
+    </li>
+
+
+    <li class="drawer-group">
+      <button class="drawer-toggle" aria-expanded="false">About Us</button>
+      <ul class="drawer-submenu">
+        <li><a href="about.html#who-we-are">Who We Are</a></li>
+        <li><a href="beginner.html">Beginners Guide</a></li>
+        <li><a href="about.html#meetings">Meetings & Attendance</a></li>
+        <li><a href="equity.html">Equity Policy</a></li>
+        <li><a href="why-pdu.html">Why PDU</a></li>
       </ul>
     </li>
 

--- a/contact.html
+++ b/contact.html
@@ -122,18 +122,6 @@
   <ul class="menu-root">
     <li><a href="index.html">Home</a></li>
     <li><a href="members.html">Members</a></li>
-
-    <li class="has-submenu">
-      <a href="about.html" class="top-link" aria-haspopup="true" aria-expanded="false">About</a>
-      <ul class="submenu" role="menu" aria-label="About submenu">
-        <li role="none"><a role="menuitem" href="about.html#who-we-are">Who We Are</a></li>
-        <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
-        <li role="none"><a role="menuitem" href="about.html#meetings">Meetings & Attendance</a></li>
-        <li role="none"><a role="menuitem" href="equity.html">Equity Policy</a></li>
-        <li role="none"><a role="menuitem" href="why-pdu.html">Why PDU</a></li>
-      </ul>
-    </li>
-
     <li class="has-submenu">
       <a href="tournaments.html" class="top-link" aria-haspopup="true" aria-expanded="false">Tournaments</a>
       <ul class="submenu" role="menu" aria-label="Tournaments submenu">
@@ -151,6 +139,18 @@
         <li role="none"><a role="menuitem" href="practicetools.html">Practice Tools</a></li>
         <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
         <li role="none"><a role="menuitem" href="resources.html">Resources Library</a></li>
+      </ul>
+    </li>
+
+
+    <li class="has-submenu">
+      <a href="about.html" class="top-link" aria-haspopup="true" aria-expanded="false">About Us</a>
+      <ul class="submenu" role="menu" aria-label="About Us submenu">
+        <li role="none"><a role="menuitem" href="about.html#who-we-are">Who We Are</a></li>
+        <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
+        <li role="none"><a role="menuitem" href="about.html#meetings">Meetings & Attendance</a></li>
+        <li role="none"><a role="menuitem" href="equity.html">Equity Policy</a></li>
+        <li role="none"><a role="menuitem" href="why-pdu.html">Why PDU</a></li>
       </ul>
     </li>
 
@@ -184,18 +184,6 @@
   <ul class="drawer-list">
     <li><a href="index.html">Home</a></li>
     <li><a href="members.html">Members</a></li>
-
-    <li class="drawer-group">
-      <button class="drawer-toggle" aria-expanded="false">About</button>
-      <ul class="drawer-submenu">
-        <li><a href="about.html#who-we-are">Who We Are</a></li>
-        <li><a href="beginner.html">Beginners Guide</a></li>
-        <li><a href="about.html#meetings">Meetings & Attendance</a></li>
-        <li><a href="equity.html">Equity Policy</a></li>
-        <li><a href="why-pdu.html">Why PDU</a></li>
-      </ul>
-    </li>
-
     <li class="drawer-group">
       <button class="drawer-toggle" aria-expanded="false">Tournaments</button>
       <ul class="drawer-submenu">
@@ -214,6 +202,18 @@
         <li><a href="practicetools.html">Practice Tools</a></li>
         <li><a href="calendar.html">Calendar</a></li>
         <li><a href="resources.html">Resources Library</a></li>
+      </ul>
+    </li>
+
+
+    <li class="drawer-group">
+      <button class="drawer-toggle" aria-expanded="false">About Us</button>
+      <ul class="drawer-submenu">
+        <li><a href="about.html#who-we-are">Who We Are</a></li>
+        <li><a href="beginner.html">Beginners Guide</a></li>
+        <li><a href="about.html#meetings">Meetings & Attendance</a></li>
+        <li><a href="equity.html">Equity Policy</a></li>
+        <li><a href="why-pdu.html">Why PDU</a></li>
       </ul>
     </li>
 

--- a/equity.html
+++ b/equity.html
@@ -33,18 +33,6 @@
   <ul class="menu-root">
     <li><a href="index.html">Home</a></li>
     <li><a href="members.html">Members</a></li>
-
-    <li class="has-submenu">
-      <a href="about.html" class="top-link" aria-haspopup="true" aria-expanded="false">About</a>
-      <ul class="submenu" role="menu" aria-label="About submenu">
-        <li role="none"><a role="menuitem" href="about.html#who-we-are">Who We Are</a></li>
-        <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
-        <li role="none"><a role="menuitem" href="about.html#meetings">Meetings & Attendance</a></li>
-        <li role="none"><a role="menuitem" href="equity.html" aria-current="page">Equity Policy</a></li>
-        <li role="none"><a role="menuitem" href="why-pdu.html">Why PDU</a></li>
-      </ul>
-    </li>
-
     <li class="has-submenu">
       <a href="tournaments.html" class="top-link" aria-haspopup="true" aria-expanded="false">Tournaments</a>
       <ul class="submenu" role="menu" aria-label="Tournaments submenu">
@@ -62,6 +50,18 @@
         <li role="none"><a role="menuitem" href="practicetools.html">Practice Tools</a></li>
         <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
         <li role="none"><a role="menuitem" href="resources.html">Resources Library</a></li>
+      </ul>
+    </li>
+
+
+    <li class="has-submenu">
+      <a href="about.html" class="top-link" aria-haspopup="true" aria-expanded="false">About Us</a>
+      <ul class="submenu" role="menu" aria-label="About Us submenu">
+        <li role="none"><a role="menuitem" href="about.html#who-we-are">Who We Are</a></li>
+        <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
+        <li role="none"><a role="menuitem" href="about.html#meetings">Meetings & Attendance</a></li>
+        <li role="none"><a role="menuitem" href="equity.html" aria-current="page">Equity Policy</a></li>
+        <li role="none"><a role="menuitem" href="why-pdu.html">Why PDU</a></li>
       </ul>
     </li>
 
@@ -95,18 +95,6 @@
   <ul class="drawer-list">
     <li><a href="index.html">Home</a></li>
     <li><a href="members.html">Members</a></li>
-
-    <li class="drawer-group">
-      <button class="drawer-toggle" aria-expanded="false">About</button>
-      <ul class="drawer-submenu">
-        <li><a href="about.html#who-we-are">Who We Are</a></li>
-        <li><a href="beginner.html">Beginners Guide</a></li>
-        <li><a href="about.html#meetings">Meetings & Attendance</a></li>
-        <li><a href="equity.html" aria-current="page">Equity Policy</a></li>
-        <li><a href="why-pdu.html">Why PDU</a></li>
-      </ul>
-    </li>
-
     <li class="drawer-group">
       <button class="drawer-toggle" aria-expanded="false">Tournaments</button>
       <ul class="drawer-submenu">
@@ -125,6 +113,18 @@
         <li><a href="practicetools.html">Practice Tools</a></li>
         <li><a href="calendar.html">Calendar</a></li>
         <li><a href="resources.html">Resources Library</a></li>
+      </ul>
+    </li>
+
+
+    <li class="drawer-group">
+      <button class="drawer-toggle" aria-expanded="false">About Us</button>
+      <ul class="drawer-submenu">
+        <li><a href="about.html#who-we-are">Who We Are</a></li>
+        <li><a href="beginner.html">Beginners Guide</a></li>
+        <li><a href="about.html#meetings">Meetings & Attendance</a></li>
+        <li><a href="equity.html" aria-current="page">Equity Policy</a></li>
+        <li><a href="why-pdu.html">Why PDU</a></li>
       </ul>
     </li>
 

--- a/index.html
+++ b/index.html
@@ -85,18 +85,6 @@
   <ul class="menu-root">
     <li><a href="index.html" aria-current="page">Home</a></li>
     <li><a href="members.html">Members</a></li>
-
-    <li class="has-submenu">
-      <a href="about.html" class="top-link" aria-haspopup="true" aria-expanded="false">About</a>
-      <ul class="submenu" role="menu" aria-label="About submenu">
-        <li role="none"><a role="menuitem" href="about.html#who-we-are">Who We Are</a></li>
-        <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
-        <li role="none"><a role="menuitem" href="about.html#meetings">Meetings & Attendance</a></li>
-        <li role="none"><a role="menuitem" href="equity.html">Equity Policy</a></li>
-        <li role="none"><a role="menuitem" href="why-pdu.html">Why PDU</a></li>
-      </ul>
-    </li>
-
     <li class="has-submenu">
       <a href="tournaments.html" class="top-link" aria-haspopup="true" aria-expanded="false">Tournaments</a>
       <ul class="submenu" role="menu" aria-label="Tournaments submenu">
@@ -114,6 +102,18 @@
         <li role="none"><a role="menuitem" href="practicetools.html">Practice Tools</a></li>
         <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
         <li role="none"><a role="menuitem" href="resources.html">Resources Library</a></li>
+      </ul>
+    </li>
+
+
+    <li class="has-submenu">
+      <a href="about.html" class="top-link" aria-haspopup="true" aria-expanded="false">About Us</a>
+      <ul class="submenu" role="menu" aria-label="About Us submenu">
+        <li role="none"><a role="menuitem" href="about.html#who-we-are">Who We Are</a></li>
+        <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
+        <li role="none"><a role="menuitem" href="about.html#meetings">Meetings & Attendance</a></li>
+        <li role="none"><a role="menuitem" href="equity.html">Equity Policy</a></li>
+        <li role="none"><a role="menuitem" href="why-pdu.html">Why PDU</a></li>
       </ul>
     </li>
 
@@ -145,18 +145,6 @@
   <ul class="drawer-list">
     <li><a href="index.html" aria-current="page">Home</a></li>
     <li><a href="members.html">Members</a></li>
-
-    <li class="drawer-group">
-      <button class="drawer-toggle" aria-expanded="false">About</button>
-      <ul class="drawer-submenu">
-        <li><a href="about.html#who-we-are">Who We Are</a></li>
-        <li><a href="beginner.html">Beginners Guide</a></li>
-        <li><a href="about.html#meetings">Meetings & Attendance</a></li>
-        <li><a href="equity.html">Equity Policy</a></li>
-        <li><a href="why-pdu.html">Why PDU</a></li>
-      </ul>
-    </li>
-
     <li class="drawer-group">
       <button class="drawer-toggle" aria-expanded="false">Tournaments</button>
       <ul class="drawer-submenu">
@@ -175,6 +163,18 @@
         <li><a href="practicetools.html">Practice Tools</a></li>
         <li><a href="calendar.html">Calendar</a></li>
         <li><a href="resources.html">Resources Library</a></li>
+      </ul>
+    </li>
+
+
+    <li class="drawer-group">
+      <button class="drawer-toggle" aria-expanded="false">About Us</button>
+      <ul class="drawer-submenu">
+        <li><a href="about.html#who-we-are">Who We Are</a></li>
+        <li><a href="beginner.html">Beginners Guide</a></li>
+        <li><a href="about.html#meetings">Meetings & Attendance</a></li>
+        <li><a href="equity.html">Equity Policy</a></li>
+        <li><a href="why-pdu.html">Why PDU</a></li>
       </ul>
     </li>
 

--- a/join.html
+++ b/join.html
@@ -184,18 +184,6 @@
   <ul class="menu-root">
     <li><a href="index.html">Home</a></li>
     <li><a href="members.html">Members</a></li>
-
-    <li class="has-submenu">
-      <a href="about.html" class="top-link" aria-haspopup="true" aria-expanded="false">About</a>
-      <ul class="submenu" role="menu" aria-label="About submenu">
-        <li role="none"><a role="menuitem" href="about.html#who-we-are">Who We Are</a></li>
-        <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
-        <li role="none"><a role="menuitem" href="about.html#meetings">Meetings & Attendance</a></li>
-        <li role="none"><a role="menuitem" href="equity.html">Equity Policy</a></li>
-        <li role="none"><a role="menuitem" href="why-pdu.html">Why PDU</a></li>
-      </ul>
-    </li>
-
     <li class="has-submenu">
       <a href="tournaments.html" class="top-link" aria-haspopup="true" aria-expanded="false">Tournaments</a>
       <ul class="submenu" role="menu" aria-label="Tournaments submenu">
@@ -213,6 +201,18 @@
         <li role="none"><a role="menuitem" href="practicetools.html">Practice Tools</a></li>
         <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
         <li role="none"><a role="menuitem" href="resources.html">Resources Library</a></li>
+      </ul>
+    </li>
+
+
+    <li class="has-submenu">
+      <a href="about.html" class="top-link" aria-haspopup="true" aria-expanded="false">About Us</a>
+      <ul class="submenu" role="menu" aria-label="About Us submenu">
+        <li role="none"><a role="menuitem" href="about.html#who-we-are">Who We Are</a></li>
+        <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
+        <li role="none"><a role="menuitem" href="about.html#meetings">Meetings & Attendance</a></li>
+        <li role="none"><a role="menuitem" href="equity.html">Equity Policy</a></li>
+        <li role="none"><a role="menuitem" href="why-pdu.html">Why PDU</a></li>
       </ul>
     </li>
 
@@ -244,18 +244,6 @@
   <ul class="drawer-list">
     <li><a href="index.html">Home</a></li>
     <li><a href="members.html">Members</a></li>
-
-    <li class="drawer-group">
-      <button class="drawer-toggle" aria-expanded="false">About</button>
-      <ul class="drawer-submenu">
-        <li><a href="about.html#who-we-are">Who We Are</a></li>
-        <li><a href="beginner.html">Beginners Guide</a></li>
-        <li><a href="about.html#meetings">Meetings & Attendance</a></li>
-        <li><a href="equity.html">Equity Policy</a></li>
-        <li><a href="why-pdu.html">Why PDU</a></li>
-      </ul>
-    </li>
-
     <li class="drawer-group">
       <button class="drawer-toggle" aria-expanded="false">Tournaments</button>
       <ul class="drawer-submenu">
@@ -274,6 +262,18 @@
         <li><a href="practicetools.html">Practice Tools</a></li>
         <li><a href="calendar.html">Calendar</a></li>
         <li><a href="resources.html">Resources Library</a></li>
+      </ul>
+    </li>
+
+
+    <li class="drawer-group">
+      <button class="drawer-toggle" aria-expanded="false">About Us</button>
+      <ul class="drawer-submenu">
+        <li><a href="about.html#who-we-are">Who We Are</a></li>
+        <li><a href="beginner.html">Beginners Guide</a></li>
+        <li><a href="about.html#meetings">Meetings & Attendance</a></li>
+        <li><a href="equity.html">Equity Policy</a></li>
+        <li><a href="why-pdu.html">Why PDU</a></li>
       </ul>
     </li>
 

--- a/judging.html
+++ b/judging.html
@@ -198,18 +198,6 @@
   <ul class="menu-root">
     <li><a href="index.html">Home</a></li>
     <li><a href="members.html">Members</a></li>
-
-    <li class="has-submenu">
-      <a href="about.html" class="top-link" aria-haspopup="true" aria-expanded="false">About</a>
-      <ul class="submenu" role="menu" aria-label="About submenu">
-        <li role="none"><a role="menuitem" href="about.html#who-we-are">Who We Are</a></li>
-        <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
-        <li role="none"><a role="menuitem" href="about.html#meetings">Meetings & Attendance</a></li>
-        <li role="none"><a role="menuitem" href="equity.html">Equity Policy</a></li>
-        <li role="none"><a role="menuitem" href="why-pdu.html">Why PDU</a></li>
-      </ul>
-    </li>
-
     <li class="has-submenu">
       <a href="tournaments.html" class="top-link" aria-haspopup="true" aria-expanded="false">Tournaments</a>
       <ul class="submenu" role="menu" aria-label="Tournaments submenu">
@@ -227,6 +215,18 @@
         <li role="none"><a role="menuitem" href="practicetools.html">Practice Tools</a></li>
         <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
         <li role="none"><a role="menuitem" href="resources.html">Resources Library</a></li>
+      </ul>
+    </li>
+
+
+    <li class="has-submenu">
+      <a href="about.html" class="top-link" aria-haspopup="true" aria-expanded="false">About Us</a>
+      <ul class="submenu" role="menu" aria-label="About Us submenu">
+        <li role="none"><a role="menuitem" href="about.html#who-we-are">Who We Are</a></li>
+        <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
+        <li role="none"><a role="menuitem" href="about.html#meetings">Meetings & Attendance</a></li>
+        <li role="none"><a role="menuitem" href="equity.html">Equity Policy</a></li>
+        <li role="none"><a role="menuitem" href="why-pdu.html">Why PDU</a></li>
       </ul>
     </li>
 
@@ -258,18 +258,6 @@
   <ul class="drawer-list">
     <li><a href="index.html">Home</a></li>
     <li><a href="members.html">Members</a></li>
-
-    <li class="drawer-group">
-      <button class="drawer-toggle" aria-expanded="false">About</button>
-      <ul class="drawer-submenu">
-        <li><a href="about.html#who-we-are">Who We Are</a></li>
-        <li><a href="beginner.html">Beginners Guide</a></li>
-        <li><a href="about.html#meetings">Meetings & Attendance</a></li>
-        <li><a href="equity.html">Equity Policy</a></li>
-        <li><a href="why-pdu.html">Why PDU</a></li>
-      </ul>
-    </li>
-
     <li class="drawer-group">
       <button class="drawer-toggle" aria-expanded="false">Tournaments</button>
       <ul class="drawer-submenu">
@@ -288,6 +276,18 @@
         <li><a href="practicetools.html">Practice Tools</a></li>
         <li><a href="calendar.html">Calendar</a></li>
         <li><a href="resources.html">Resources Library</a></li>
+      </ul>
+    </li>
+
+
+    <li class="drawer-group">
+      <button class="drawer-toggle" aria-expanded="false">About Us</button>
+      <ul class="drawer-submenu">
+        <li><a href="about.html#who-we-are">Who We Are</a></li>
+        <li><a href="beginner.html">Beginners Guide</a></li>
+        <li><a href="about.html#meetings">Meetings & Attendance</a></li>
+        <li><a href="equity.html">Equity Policy</a></li>
+        <li><a href="why-pdu.html">Why PDU</a></li>
       </ul>
     </li>
 

--- a/leadership.html
+++ b/leadership.html
@@ -209,18 +209,6 @@
   <ul class="menu-root">
     <li><a href="index.html">Home</a></li>
     <li><a href="members.html">Members</a></li>
-
-    <li class="has-submenu">
-      <a href="about.html" class="top-link" aria-haspopup="true" aria-expanded="false">About</a>
-      <ul class="submenu" role="menu" aria-label="About submenu">
-        <li role="none"><a role="menuitem" href="about.html#who-we-are">Who We Are</a></li>
-        <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
-        <li role="none"><a role="menuitem" href="about.html#meetings">Meetings & Attendance</a></li>
-        <li role="none"><a role="menuitem" href="equity.html">Equity Policy</a></li>
-        <li role="none"><a role="menuitem" href="why-pdu.html">Why PDU</a></li>
-      </ul>
-    </li>
-
     <li class="has-submenu">
       <a href="tournaments.html" class="top-link" aria-haspopup="true" aria-expanded="false">Tournaments</a>
       <ul class="submenu" role="menu" aria-label="Tournaments submenu">
@@ -238,6 +226,18 @@
         <li role="none"><a role="menuitem" href="practicetools.html">Practice Tools</a></li>
         <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
         <li role="none"><a role="menuitem" href="resources.html">Resources Library</a></li>
+      </ul>
+    </li>
+
+
+    <li class="has-submenu">
+      <a href="about.html" class="top-link" aria-haspopup="true" aria-expanded="false">About Us</a>
+      <ul class="submenu" role="menu" aria-label="About Us submenu">
+        <li role="none"><a role="menuitem" href="about.html#who-we-are">Who We Are</a></li>
+        <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
+        <li role="none"><a role="menuitem" href="about.html#meetings">Meetings & Attendance</a></li>
+        <li role="none"><a role="menuitem" href="equity.html">Equity Policy</a></li>
+        <li role="none"><a role="menuitem" href="why-pdu.html">Why PDU</a></li>
       </ul>
     </li>
 
@@ -271,18 +271,6 @@
   <ul class="drawer-list">
     <li><a href="index.html">Home</a></li>
     <li><a href="members.html">Members</a></li>
-
-    <li class="drawer-group">
-      <button class="drawer-toggle" aria-expanded="false">About</button>
-      <ul class="drawer-submenu">
-        <li><a href="about.html#who-we-are">Who We Are</a></li>
-        <li><a href="beginner.html">Beginners Guide</a></li>
-        <li><a href="about.html#meetings">Meetings & Attendance</a></li>
-        <li><a href="equity.html">Equity Policy</a></li>
-        <li><a href="why-pdu.html">Why PDU</a></li>
-      </ul>
-    </li>
-
     <li class="drawer-group">
       <button class="drawer-toggle" aria-expanded="false">Tournaments</button>
       <ul class="drawer-submenu">
@@ -301,6 +289,18 @@
         <li><a href="practicetools.html">Practice Tools</a></li>
         <li><a href="calendar.html">Calendar</a></li>
         <li><a href="resources.html">Resources Library</a></li>
+      </ul>
+    </li>
+
+
+    <li class="drawer-group">
+      <button class="drawer-toggle" aria-expanded="false">About Us</button>
+      <ul class="drawer-submenu">
+        <li><a href="about.html#who-we-are">Who We Are</a></li>
+        <li><a href="beginner.html">Beginners Guide</a></li>
+        <li><a href="about.html#meetings">Meetings & Attendance</a></li>
+        <li><a href="equity.html">Equity Policy</a></li>
+        <li><a href="why-pdu.html">Why PDU</a></li>
       </ul>
     </li>
 

--- a/members.html
+++ b/members.html
@@ -118,18 +118,6 @@
   <ul class="menu-root">
     <li><a href="index.html">Home</a></li>
     <li><a href="members.html" aria-current="page">Members</a></li>
-
-    <li class="has-submenu">
-      <a href="about.html" class="top-link" aria-haspopup="true" aria-expanded="false">About</a>
-      <ul class="submenu" role="menu" aria-label="About submenu">
-        <li role="none"><a role="menuitem" href="about.html#who-we-are">Who We Are</a></li>
-        <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
-        <li role="none"><a role="menuitem" href="about.html#meetings">Meetings & Attendance</a></li>
-        <li role="none"><a role="menuitem" href="equity.html">Equity Policy</a></li>
-        <li role="none"><a role="menuitem" href="why-pdu.html">Why PDU</a></li>
-      </ul>
-    </li>
-
     <li class="has-submenu">
       <a href="tournaments.html" class="top-link" aria-haspopup="true" aria-expanded="false">Tournaments</a>
       <ul class="submenu" role="menu" aria-label="Tournaments submenu">
@@ -147,6 +135,18 @@
         <li role="none"><a role="menuitem" href="practicetools.html">Practice Tools</a></li>
         <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
         <li role="none"><a role="menuitem" href="resources.html">Resources Library</a></li>
+      </ul>
+    </li>
+
+
+    <li class="has-submenu">
+      <a href="about.html" class="top-link" aria-haspopup="true" aria-expanded="false">About Us</a>
+      <ul class="submenu" role="menu" aria-label="About Us submenu">
+        <li role="none"><a role="menuitem" href="about.html#who-we-are">Who We Are</a></li>
+        <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
+        <li role="none"><a role="menuitem" href="about.html#meetings">Meetings & Attendance</a></li>
+        <li role="none"><a role="menuitem" href="equity.html">Equity Policy</a></li>
+        <li role="none"><a role="menuitem" href="why-pdu.html">Why PDU</a></li>
       </ul>
     </li>
 
@@ -178,18 +178,6 @@
   <ul class="drawer-list">
     <li><a href="index.html">Home</a></li>
     <li><a href="members.html" aria-current="page">Members</a></li>
-
-    <li class="drawer-group">
-      <button class="drawer-toggle" aria-expanded="false">About</button>
-      <ul class="drawer-submenu">
-        <li><a href="about.html#who-we-are">Who We Are</a></li>
-        <li><a href="beginner.html">Beginners Guide</a></li>
-        <li><a href="about.html#meetings">Meetings & Attendance</a></li>
-        <li><a href="equity.html">Equity Policy</a></li>
-        <li><a href="why-pdu.html">Why PDU</a></li>
-      </ul>
-    </li>
-
     <li class="drawer-group">
       <button class="drawer-toggle" aria-expanded="false">Tournaments</button>
       <ul class="drawer-submenu">
@@ -208,6 +196,18 @@
         <li><a href="practicetools.html">Practice Tools</a></li>
         <li><a href="calendar.html">Calendar</a></li>
         <li><a href="resources.html">Resources Library</a></li>
+      </ul>
+    </li>
+
+
+    <li class="drawer-group">
+      <button class="drawer-toggle" aria-expanded="false">About Us</button>
+      <ul class="drawer-submenu">
+        <li><a href="about.html#who-we-are">Who We Are</a></li>
+        <li><a href="beginner.html">Beginners Guide</a></li>
+        <li><a href="about.html#meetings">Meetings & Attendance</a></li>
+        <li><a href="equity.html">Equity Policy</a></li>
+        <li><a href="why-pdu.html">Why PDU</a></li>
       </ul>
     </li>
 

--- a/practicetools.html
+++ b/practicetools.html
@@ -227,18 +227,6 @@
   <ul class="menu-root">
     <li><a href="index.html">Home</a></li>
     <li><a href="members.html">Members</a></li>
-
-    <li class="has-submenu">
-      <a href="about.html" class="top-link" aria-haspopup="true" aria-expanded="false">About</a>
-      <ul class="submenu" role="menu" aria-label="About submenu">
-        <li role="none"><a role="menuitem" href="about.html#who-we-are">Who We Are</a></li>
-        <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
-        <li role="none"><a role="menuitem" href="about.html#meetings">Meetings & Attendance</a></li>
-        <li role="none"><a role="menuitem" href="equity.html">Equity Policy</a></li>
-        <li role="none"><a role="menuitem" href="why-pdu.html">Why PDU</a></li>
-      </ul>
-    </li>
-
     <li class="has-submenu">
       <a href="tournaments.html" class="top-link" aria-haspopup="true" aria-expanded="false">Tournaments</a>
       <ul class="submenu" role="menu" aria-label="Tournaments submenu">
@@ -256,6 +244,18 @@
         <li role="none"><a role="menuitem" href="practicetools.html" aria-current="page">Practice Tools</a></li>
         <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
         <li role="none"><a role="menuitem" href="resources.html">Resources Library</a></li>
+      </ul>
+    </li>
+
+
+    <li class="has-submenu">
+      <a href="about.html" class="top-link" aria-haspopup="true" aria-expanded="false">About Us</a>
+      <ul class="submenu" role="menu" aria-label="About Us submenu">
+        <li role="none"><a role="menuitem" href="about.html#who-we-are">Who We Are</a></li>
+        <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
+        <li role="none"><a role="menuitem" href="about.html#meetings">Meetings & Attendance</a></li>
+        <li role="none"><a role="menuitem" href="equity.html">Equity Policy</a></li>
+        <li role="none"><a role="menuitem" href="why-pdu.html">Why PDU</a></li>
       </ul>
     </li>
 
@@ -287,18 +287,6 @@
   <ul class="drawer-list">
     <li><a href="index.html">Home</a></li>
     <li><a href="members.html">Members</a></li>
-
-    <li class="drawer-group">
-      <button class="drawer-toggle" aria-expanded="false">About</button>
-      <ul class="drawer-submenu">
-        <li><a href="about.html#who-we-are">Who We Are</a></li>
-        <li><a href="beginner.html">Beginners Guide</a></li>
-        <li><a href="about.html#meetings">Meetings & Attendance</a></li>
-        <li><a href="equity.html">Equity Policy</a></li>
-        <li><a href="why-pdu.html">Why PDU</a></li>
-      </ul>
-    </li>
-
     <li class="drawer-group">
       <button class="drawer-toggle" aria-expanded="false">Tournaments</button>
       <ul class="drawer-submenu">
@@ -317,6 +305,18 @@
         <li><a href="practicetools.html" aria-current="page">Practice Tools</a></li>
         <li><a href="calendar.html">Calendar</a></li>
         <li><a href="resources.html">Resources Library</a></li>
+      </ul>
+    </li>
+
+
+    <li class="drawer-group">
+      <button class="drawer-toggle" aria-expanded="false">About Us</button>
+      <ul class="drawer-submenu">
+        <li><a href="about.html#who-we-are">Who We Are</a></li>
+        <li><a href="beginner.html">Beginners Guide</a></li>
+        <li><a href="about.html#meetings">Meetings & Attendance</a></li>
+        <li><a href="equity.html">Equity Policy</a></li>
+        <li><a href="why-pdu.html">Why PDU</a></li>
       </ul>
     </li>
 

--- a/resources.html
+++ b/resources.html
@@ -153,18 +153,6 @@
   <ul class="menu-root">
     <li><a href="index.html">Home</a></li>
     <li><a href="members.html">Members</a></li>
-
-    <li class="has-submenu">
-      <a href="about.html" class="top-link" aria-haspopup="true" aria-expanded="false">About</a>
-      <ul class="submenu" role="menu" aria-label="About submenu">
-        <li role="none"><a role="menuitem" href="about.html#who-we-are">Who We Are</a></li>
-        <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
-        <li role="none"><a role="menuitem" href="about.html#meetings">Meetings & Attendance</a></li>
-        <li role="none"><a role="menuitem" href="equity.html">Equity Policy</a></li>
-        <li role="none"><a role="menuitem" href="why-pdu.html">Why PDU</a></li>
-      </ul>
-    </li>
-
     <li class="has-submenu">
       <a href="tournaments.html" class="top-link" aria-haspopup="true" aria-expanded="false">Tournaments</a>
       <ul class="submenu" role="menu" aria-label="Tournaments submenu">
@@ -182,6 +170,18 @@
         <li role="none"><a role="menuitem" href="practicetools.html">Practice Tools</a></li>
         <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
         <li role="none"><a role="menuitem" href="resources.html" aria-current="page">Resources Library</a></li>
+      </ul>
+    </li>
+
+
+    <li class="has-submenu">
+      <a href="about.html" class="top-link" aria-haspopup="true" aria-expanded="false">About Us</a>
+      <ul class="submenu" role="menu" aria-label="About Us submenu">
+        <li role="none"><a role="menuitem" href="about.html#who-we-are">Who We Are</a></li>
+        <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
+        <li role="none"><a role="menuitem" href="about.html#meetings">Meetings & Attendance</a></li>
+        <li role="none"><a role="menuitem" href="equity.html">Equity Policy</a></li>
+        <li role="none"><a role="menuitem" href="why-pdu.html">Why PDU</a></li>
       </ul>
     </li>
 
@@ -213,18 +213,6 @@
   <ul class="drawer-list">
     <li><a href="index.html">Home</a></li>
     <li><a href="members.html">Members</a></li>
-
-    <li class="drawer-group">
-      <button class="drawer-toggle" aria-expanded="false">About</button>
-      <ul class="drawer-submenu">
-        <li><a href="about.html#who-we-are">Who We Are</a></li>
-        <li><a href="beginner.html">Beginners Guide</a></li>
-        <li><a href="about.html#meetings">Meetings & Attendance</a></li>
-        <li><a href="equity.html">Equity Policy</a></li>
-        <li><a href="why-pdu.html">Why PDU</a></li>
-      </ul>
-    </li>
-
     <li class="drawer-group">
       <button class="drawer-toggle" aria-expanded="false">Tournaments</button>
       <ul class="drawer-submenu">
@@ -243,6 +231,18 @@
         <li><a href="practicetools.html">Practice Tools</a></li>
         <li><a href="calendar.html">Calendar</a></li>
         <li><a href="resources.html" aria-current="page">Resources Library</a></li>
+      </ul>
+    </li>
+
+
+    <li class="drawer-group">
+      <button class="drawer-toggle" aria-expanded="false">About Us</button>
+      <ul class="drawer-submenu">
+        <li><a href="about.html#who-we-are">Who We Are</a></li>
+        <li><a href="beginner.html">Beginners Guide</a></li>
+        <li><a href="about.html#meetings">Meetings & Attendance</a></li>
+        <li><a href="equity.html">Equity Policy</a></li>
+        <li><a href="why-pdu.html">Why PDU</a></li>
       </ul>
     </li>
 

--- a/tournaments.html
+++ b/tournaments.html
@@ -101,18 +101,6 @@
   <ul class="menu-root">
     <li><a href="index.html">Home</a></li>
     <li><a href="members.html">Members</a></li>
-
-    <li class="has-submenu">
-      <a href="about.html" class="top-link" aria-haspopup="true" aria-expanded="false">About</a>
-      <ul class="submenu" role="menu" aria-label="About submenu">
-        <li role="none"><a role="menuitem" href="about.html#who-we-are">Who We Are</a></li>
-        <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
-        <li role="none"><a role="menuitem" href="about.html#meetings">Meetings & Attendance</a></li>
-        <li role="none"><a role="menuitem" href="equity.html">Equity Policy</a></li>
-        <li role="none"><a role="menuitem" href="why-pdu.html">Why PDU</a></li>
-      </ul>
-    </li>
-
     <li class="has-submenu">
       <a href="tournaments.html" class="top-link" aria-current="page" aria-haspopup="true" aria-expanded="false">Tournaments</a>
       <ul class="submenu" role="menu" aria-label="Tournaments submenu">
@@ -130,6 +118,18 @@
         <li role="none"><a role="menuitem" href="practicetools.html">Practice Tools</a></li>
         <li role="none"><a role="menuitem" href="calendar.html">Calendar</a></li>
         <li role="none"><a role="menuitem" href="resources.html">Resources Library</a></li>
+      </ul>
+    </li>
+
+
+    <li class="has-submenu">
+      <a href="about.html" class="top-link" aria-haspopup="true" aria-expanded="false">About Us</a>
+      <ul class="submenu" role="menu" aria-label="About Us submenu">
+        <li role="none"><a role="menuitem" href="about.html#who-we-are">Who We Are</a></li>
+        <li role="none"><a role="menuitem" href="beginner.html">Beginners Guide</a></li>
+        <li role="none"><a role="menuitem" href="about.html#meetings">Meetings & Attendance</a></li>
+        <li role="none"><a role="menuitem" href="equity.html">Equity Policy</a></li>
+        <li role="none"><a role="menuitem" href="why-pdu.html">Why PDU</a></li>
       </ul>
     </li>
 
@@ -161,18 +161,6 @@
   <ul class="drawer-list">
     <li><a href="index.html">Home</a></li>
     <li><a href="members.html">Members</a></li>
-
-    <li class="drawer-group">
-      <button class="drawer-toggle" aria-expanded="false">About</button>
-      <ul class="drawer-submenu">
-        <li><a href="about.html#who-we-are">Who We Are</a></li>
-        <li><a href="beginner.html">Beginners Guide</a></li>
-        <li><a href="about.html#meetings">Meetings & Attendance</a></li>
-        <li><a href="equity.html">Equity Policy</a></li>
-        <li><a href="why-pdu.html">Why PDU</a></li>
-      </ul>
-    </li>
-
     <li class="drawer-group">
       <button class="drawer-toggle" aria-expanded="false" aria-current="page">Tournaments</button>
       <ul class="drawer-submenu">
@@ -191,6 +179,18 @@
         <li><a href="practicetools.html">Practice Tools</a></li>
         <li><a href="calendar.html">Calendar</a></li>
         <li><a href="resources.html">Resources Library</a></li>
+      </ul>
+    </li>
+
+
+    <li class="drawer-group">
+      <button class="drawer-toggle" aria-expanded="false">About Us</button>
+      <ul class="drawer-submenu">
+        <li><a href="about.html#who-we-are">Who We Are</a></li>
+        <li><a href="beginner.html">Beginners Guide</a></li>
+        <li><a href="about.html#meetings">Meetings & Attendance</a></li>
+        <li><a href="equity.html">Equity Policy</a></li>
+        <li><a href="why-pdu.html">Why PDU</a></li>
       </ul>
     </li>
 


### PR DESCRIPTION
## Summary
- Reorder main navigation links globally to: Home, Members, Tournaments, Join Us, About Us, Leadership, Contact.
- Rename "About" to "About Us" in desktop and mobile menus and update corresponding submenu labels.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0e218eee48322830f0cc518d562ce