### PR TITLE
Replace upcoming tournament names with TBD

### DIFF
--- a/about.html
+++ b/about.html
@@ -169,7 +169,7 @@
         The Parliamentary Debate Union (PDU) at New York University is a student-run club devoted to competitive debate, intellectual growth, and team camaraderie.
         We represent NYU on the American Parliamentary Debate Association (APDA) circuit, a collegiate league of debate teams from universities across the East Coast and beyond.
         <br><br>
-        Each weekend, we send teams to tournaments at colleges like Yale, Princeton, and Harvard, fully funded and supported. PDU covers all travel expenses for competing members, including transportation, registration, and lodging.
+          Each weekend, we send teams to tournaments at colleges across the region, fully funded and supported. PDU covers all travel expenses for competing members, including transportation, registration, and lodging.
         <br><br>
         Beyond competition, PDU offers weekly training workshops, practice debates, and mentorship. We welcome everyone from seasoned debaters to complete beginners and provide the tools, strategies, and community to help every member succeed.
         <br><br>

--- a/index.html
+++ b/index.html
@@ -258,31 +258,31 @@
       <div class="h-scroll">
         <article class="event-card">
           <div class="event-head">
-            <h4>Yale IV</h4>
-            <span class="pill">Oct 4–5</span>
+              <h4>TBD</h4>
+              <span class="pill">Dates TBD</span>
           </div>
-          <p class="event-meta">New Haven, CT · 5 prelims · Break to Octos</p>
-          <p class="event-note">Travel, reg, lodging covered.</p>
+            <p class="event-meta">Details to be announced.</p>
+            <p class="event-note">Check back soon for more info.</p>
           <a class="link-chip" href="tournaments.html">Details →</a>
         </article>
 
         <article class="event-card">
           <div class="event-head">
-            <h4>Princeton Pro-Ams</h4>
-            <span class="pill">Oct 18–19</span>
+              <h4>TBD</h4>
+              <span class="pill">Dates TBD</span>
           </div>
-          <p class="event-meta">Princeton, NJ · Novice friendly</p>
-          <p class="event-note">Great for first-timers.</p>
+            <p class="event-meta">Details to be announced.</p>
+            <p class="event-note">Check back soon for more info.</p>
           <a class="link-chip" href="tournaments.html">Details →</a>
         </article>
 
         <article class="event-card">
           <div class="event-head">
-            <h4>Harvard Invitational</h4>
-            <span class="pill">Nov 1–2</span>
+              <h4>TBD</h4>
+              <span class="pill">Dates TBD</span>
           </div>
-          <p class="event-meta">Cambridge, MA · Large field</p>
-          <p class="event-note">High-energy weekend.</p>
+            <p class="event-meta">Details to be announced.</p>
+            <p class="event-note">Check back soon for more info.</p>
           <a class="link-chip" href="tournaments.html">Details →</a>
         </article>
       </div>
@@ -311,7 +311,7 @@
       </div>
       <div class="highlight-body">
         <h3 class="about-header">Recent Highlights</h3>
-        <p>Quarterfinals at Princeton + Top 10 Speaks. Big shoutout to our novice squads — huge strides this month.</p>
+          <p>Quarterfinals at a recent tournament + Top 10 Speaks. Big shoutout to our novice squads — huge strides this month.</p>
         <a class="link-chip" href="tournaments.html">See results & recaps →</a>
       </div>
     </section>

--- a/join.html
+++ b/join.html
@@ -399,7 +399,7 @@
           <ul>
             <li>Kickoff lessons begin</li>
             <li>First scrim night</li>
-            <li>Travel: Yale (placeholder)</li>
+              <li>Travel: TBD (placeholder)</li>
           </ul>
           <div class="cta-row"><a class="link-chip" href="calendar.html">Open calendar →</a></div>
         </div>
@@ -407,7 +407,7 @@
           <h4>October</h4>
           <ul>
             <li>Casebuilding workshop</li>
-            <li>Travel: Princeton (placeholder)</li>
+              <li>Travel: TBD (placeholder)</li>
             <li>Novice spotlight night</li>
           </ul>
           <div class="cta-row"><a class="link-chip" href="calendar.html">Open calendar →</a></div>
@@ -416,7 +416,7 @@
           <h4>November</h4>
           <ul>
             <li>Mid-semester scrim series</li>
-            <li>Travel: Harvard (placeholder)</li>
+              <li>Travel: TBD (placeholder)</li>
             <li>Judge training basics</li>
           </ul>
           <div class="cta-row"><a class="link-chip" href="calendar.html">Open calendar →</a></div>

--- a/members.html
+++ b/members.html
@@ -233,7 +233,7 @@
       <div class="dash-card accent-info span-12">
         <div class="stat-row">
           <span class="stat-chip"><i class="dot purple blink"></i> <span id="memberCountdown">Calculating next meeting…</span></span>
-          <span class="stat-chip"><i class="dot purple"></i> Next tournament: <strong>Sep 12</strong></span>
+            <span class="stat-chip"><i class="dot purple"></i> Next tournament: <strong>TBD</strong></span>
         </div>
       </div>
     </div>
@@ -272,36 +272,36 @@
             </p>
 
             <div class="targets-grid overview">
-              <!-- Princeton Invitational -->
+              <!-- TBD -->
               <article class="target-card">
                 <span class="pill open">Sign-ups Open</span>
-                <div class="chip-row"><span class="chip">Sep 12–13</span><span class="chip">Northeast</span></div>
-                <h3>Princeton Invitational</h3>
-                <p class="about-preview" style="margin:.55rem 0 .65rem;">Balanced field; great for new partnerships and experienced teams alike.</p>
+                  <div class="chip-row"><span class="chip">Dates TBD</span><span class="chip">Region TBD</span></div>
+                  <h3>TBD</h3>
+                  <p class="about-preview" style="margin:.55rem 0 .65rem;">Details to be announced.</p>
                 <div class="cta-row">
                   <a class="link-chip" href="tournaments.html">Details →</a>
                   <a class="link-chip" href="calendar.html">Calendar →</a>
                 </div>
               </article>
 
-              <!-- Harvard Intervarsity -->
+              <!-- TBD -->
               <article class="target-card">
                 <span class="pill tentative">Tentative</span>
-                <div class="chip-row"><span class="chip">Sep 19–20</span><span class="chip">Northeast</span></div>
-                <h3>Harvard Intervarsity</h3>
-                <p class="about-preview" style="margin:.55rem 0 .65rem;">Competitive field; strong option for experienced pairs aiming to break.</p>
+                  <div class="chip-row"><span class="chip">Dates TBD</span><span class="chip">Region TBD</span></div>
+                  <h3>TBD</h3>
+                  <p class="about-preview" style="margin:.55rem 0 .65rem;">Details to be announced.</p>
                 <div class="cta-row">
                   <a class="link-chip" href="tournaments.html">Details →</a>
                   <a class="link-chip" href="calendar.html">Calendar →</a>
                 </div>
               </article>
 
-              <!-- Columbia Fall Open -->
+              <!-- TBD -->
               <article class="target-card">
                 <span class="pill confirmed">Roster Confirmed</span>
-                <div class="chip-row"><span class="chip">Sep 26–27</span><span class="chip">NYC</span></div>
-                <h3>Columbia Fall Open</h3>
-                <p class="about-preview" style="margin:.55rem 0 .65rem;">Close to home with a strong judging pool; excellent learning weekend.</p>
+                  <div class="chip-row"><span class="chip">Dates TBD</span><span class="chip">Region TBD</span></div>
+                  <h3>TBD</h3>
+                  <p class="about-preview" style="margin:.55rem 0 .65rem;">Details to be announced.</p>
                 <div class="cta-row">
                   <a class="link-chip" href="tournaments.html">Details →</a>
                   <a class="link-chip" href="calendar.html">Calendar →</a>

--- a/tournaments.html
+++ b/tournaments.html
@@ -242,7 +242,7 @@
       <div class="feature-card">
         <div class="feature-left">
           <div class="event-head">
-            <h3>Yale IV (Placeholder)</h3>
+            <h3>TBD</h3>
             <span class="pill open">Sign-ups open</span>
           </div>
           <div class="event-badges">
@@ -254,13 +254,13 @@
             </span>
           </div>
           <div class="meta">
-            <span class="chip">New Haven, CT</span>
-            <span class="chip">Fri–Sat (Placeholder)</span>
+            <span class="chip">Location TBD</span>
+            <span class="chip">Dates TBD</span>
           </div>
-          <p class="muted">A classic early-fall tournament with a large field and a brisk break. Great for motivated pairs and confident novices.</p>
+          <p class="muted">Details coming soon.</p>
           <ul class="section-list" style="margin-top:.6rem;">
-            <li><strong>Interest form closes:</strong> Sep 20, 11:59 PM ET (placeholder)</li>
-            <li><strong>Travel window:</strong> Fri afternoon → Sat late night (placeholder)</li>
+            <li><strong>Interest form closes:</strong> TBD</li>
+            <li><strong>Travel window:</strong> TBD</li>
             <li><strong>Funding:</strong> PDU covers travel, registration, lodging.</li>
           </ul>
           <div class="cta-row" style="margin-top:.75rem;">
@@ -290,7 +290,7 @@
         <!-- Card 1: Sign-ups Open (shows Interest Form) -->
         <article class="target-card" role="listitem">
           <div class="event-head">
-            <h4>Princeton Invitational</h4>
+              <h4>TBD</h4>
             <span class="pill open">Sign-ups open</span>
           </div>
           <div class="event-badges">
@@ -301,10 +301,10 @@
               <span class="badge-text">Judges needed: <strong class="need-count">TBD</strong></span>
             </span>
           </div>
-          <div class="meta">
-            <span class="chip">Oct 3–4 (Placeholder)</span>
-          </div>
-          <p class="about-preview" style="margin:.25rem 0 .4rem;">Balanced field, good for new partnerships and experienced teams alike.</p>
+            <div class="meta">
+              <span class="chip">Dates TBD</span>
+            </div>
+            <p class="about-preview" style="margin:.25rem 0 .4rem;">Details to be announced.</p>
           <div class="cta-row">
             <a class="link-chip" href="#" title="Placeholder link for interest form" target="_blank" rel="noopener">Interest form →</a>
             <a class="link-chip" href="calendar.html">Calendar →</a>
@@ -316,7 +316,7 @@
         <!-- Card 2: Tentative -->
         <article class="target-card" role="listitem">
           <div class="event-head">
-            <h4>Harvard Intervarsity</h4>
+              <h4>TBD</h4>
             <span class="pill tentative">Tentative</span>
           </div>
           <div class="event-badges">
@@ -327,10 +327,10 @@
               <span class="badge-text">Judges needed: <strong class="need-count">2</strong></span>
             </span>
           </div>
-          <div class="meta">
-            <span class="chip">Oct 24–25 (Placeholder)</span>
-          </div>
-          <p class="about-preview" style="margin:.25rem 0 .4rem;">Large, competitive field; good for experienced pairs aiming to break.</p>
+            <div class="meta">
+              <span class="chip">Dates TBD</span>
+            </div>
+            <p class="about-preview" style="margin:.25rem 0 .4rem;">Details to be announced.</p>
           <div class="cta-row">
             <a class="link-chip" href="calendar.html">Calendar →</a>
             <a class="link-chip" href="https://drive.google.com/drive/folders/1SIot57czQp_hxY6Bx38I_SN4deVhbvDo?usp=drive_link" target="_blank" rel="noopener">TID →</a>
@@ -340,7 +340,7 @@
         <!-- Card 3: Confirmed -->
         <article class="target-card" role="listitem">
           <div class="event-head">
-            <h4>Columbia Fall Open</h4>
+              <h4>TBD</h4>
             <span class="pill confirmed">Roster Confirmed</span>
           </div>
           <div class="event-badges">
@@ -351,10 +351,10 @@
               <span class="badge-text">Judges needed: <strong class="need-count">0</strong></span>
             </span>
           </div>
-          <div class="meta">
-            <span class="chip">Nov 7–8 (Placeholder)</span>
-          </div>
-          <p class="about-preview" style="margin:.25rem 0 .4rem;">Close to home with strong judging pool; good learning weekend.</p>
+            <div class="meta">
+              <span class="chip">Dates TBD</span>
+            </div>
+            <p class="about-preview" style="margin:.25rem 0 .4rem;">Details to be announced.</p>
           <div class="cta-row">
             <a class="link-chip" href="calendar.html">Calendar →</a>
             <a class="link-chip" href="https://drive.google.com/drive/folders/1SIot57czQp_hxY6Bx38I_SN4deVhbvDo?usp=drive_link" target="_blank" rel="noopener">TID →</a>
@@ -364,7 +364,7 @@
         <!-- Card 4: Tentative -->
         <article class="target-card" role="listitem">
           <div class="event-head">
-            <h4>Northeastern Open</h4>
+              <h4>TBD</h4>
             <span class="pill tentative">Tentative</span>
           </div>
           <div class="event-badges">
@@ -375,10 +375,10 @@
               <span class="badge-text">Judges needed: <strong class="need-count">1</strong></span>
             </span>
           </div>
-          <div class="meta">
-            <span class="chip">Dec 5–6 (Placeholder)</span>
-          </div>
-          <p class="about-preview" style="margin:.25rem 0 .4rem;">Great late-semester reps; friendly tournament culture.</p>
+            <div class="meta">
+              <span class="chip">Dates TBD</span>
+            </div>
+            <p class="about-preview" style="margin:.25rem 0 .4rem;">Details to be announced.</p>
           <div class="cta-row">
             <a class="link-chip" href="calendar.html">Calendar →</a>
             <a class="link-chip" href="https://drive.google.com/drive/folders/1SIot57czQp_hxY6Bx38I_SN4deVhbvDo?usp=drive_link" target="_blank" rel="noopener">TID →</a>


### PR DESCRIPTION
## Summary
- replace all named upcoming tournaments with "TBD" on tournaments, members, and landing pages
- swap out specific school references for generic placeholders
- update join page schedule placeholders

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b79bb060c08322ab371e7b66b70487