### PR TITLE
Use general images for home page galleries

### DIFF
--- a/index.html
+++ b/index.html
@@ -325,16 +325,16 @@
   <section class="photo-rail" aria-label="Club photos">
     <div class="rail-wrap">
       <figure class="rail-item">
-        <img src="catalog1.jpg" alt="PDU team at a tournament venue" loading="lazy">
+        <img src="IMG_2178.JPEG" alt="General club photo 1" loading="lazy">
       </figure>
       <figure class="rail-item">
-        <img src="catalog2.jpg" alt="Two PDU debaters prepping before a round" loading="lazy">
+        <img src="IMG_2199.JPEG" alt="General club photo 2" loading="lazy">
       </figure>
       <figure class="rail-item">
-        <img src="catalog3.jpg" alt="Judging and feedback session during practice" loading="lazy">
+        <img src="IMG_3138.JPEG" alt="General club photo 3" loading="lazy">
       </figure>
       <figure class="rail-item">
-        <img src="catalog4.jpg" alt="Team travel moment on the APDA circuit" loading="lazy">
+        <img src="IMG_4879.JPEG" alt="General club photo 4" loading="lazy">
       </figure>
     </div>
   </section>
@@ -342,7 +342,7 @@
   <!-- Lightbox (click any photo) -->
   <div class="lightbox" id="lightbox" aria-modal="true" role="dialog" aria-label="Image viewer">
     <button id="lightboxClose" aria-label="Close image">Close</button>
-    <img id="lightboxImg" src="" alt="">
+    <img id="lightboxImg" src="about:blank" alt="">
   </div>
 
   <main class="main-content">
@@ -434,6 +434,17 @@
         <li>Beginner-friendly training & mentorship</li>
         <li>A supportive, competitive community</li>
       </ul>
+      <div class="rail-wrap" style="margin-top:1rem;">
+        <figure class="rail-item">
+          <img src="20250416_204645.jpg" alt="Team gathering" loading="lazy">
+        </figure>
+        <figure class="rail-item">
+          <img src="IMG_5720.JPEG" alt="Debaters in action" loading="lazy">
+        </figure>
+        <figure class="rail-item">
+          <img src="image000000.jpg" alt="Travel snapshot" loading="lazy">
+        </figure>
+      </div>
       <div class="cta-row">
         <a class="link-chip" href="why-pdu.html">Read the full Why PDU →</a>
       </div>


### PR DESCRIPTION
## Summary
- Swap catalog placeholders in the home page photo rail for random general photos.
- Add a new mini photo rail in the Why PDU card using general images.
- Initialize lightbox image with a blank placeholder to satisfy HTML linting.

## Testing
- `npx -y htmlhint index.html`

------
https://chatgpt.com/codex/tasks/task_e_68b7c0715c9c832283f023e7c3e8597e