### PR TITLE
Remove em dashes from site text

### DIFF
--- a/about.html
+++ b/about.html
@@ -205,14 +205,14 @@
             <span class="chip">Twice weekly</span>
           </div>
 
-          <p class="subhead">Monday — Lesson Meeting</p>
+          <p class="subhead">Monday  -  Lesson Meeting</p>
           <ul class="section-list">
             <li><strong>Lecture:</strong> Focused lesson on a debate skill or technique.</li>
             <li><strong>Engagement:</strong> Short activities to check understanding.</li>
             <li><strong>Practice Rounds:</strong> Full simulated debates to apply the lesson.</li>
           </ul>
 
-          <p class="subhead" style="margin-top:1rem;">Wednesday — Training Meeting</p>
+          <p class="subhead" style="margin-top:1rem;">Wednesday  -  Training Meeting</p>
           <ul class="section-list">
             <li><strong>Practice Round:</strong> A full simulated debate round.</li>
             <li><strong>Workshopping:</strong> Case-building with senior members and the board.</li>
@@ -222,7 +222,7 @@
 
         <div>
           <p class="subhead">Attendance Policy</p>
-          <p class="note">Attendance isn’t mandatory, but participation matters—especially for limited spots.</p>
+          <p class="note">Attendance isn’t mandatory, but participation matters - especially for limited spots.</p>
           <ul class="section-list">
             <li><strong>Tournament eligibility (last 3 weeks before interest form):</strong></li>
             <ul class="section-list">
@@ -256,7 +256,7 @@
     <section class="glass-card" id="judging">
       <h3 class="about-header">Judging</h3>
       <p class="about-preview">
-        Great rounds need great judges. Judging grows your analysis, helps newer teams get clear feedback, and keeps tournaments running smoothly. If you’re curious, you’re qualified—we’ll show you how.
+        Great rounds need great judges. Judging grows your analysis, helps newer teams get clear feedback, and keeps tournaments running smoothly. If you’re curious, you’re qualified - we’ll show you how.
       </p>
       <ul class="section-list">
         <li><strong>Before round:</strong> Read the case statement, track protected time, and note content warnings (CWs).</li>

--- a/advanced.html
+++ b/advanced.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <!-- =========================================
-       ADVANCED APDA GUIDE — NYU PDU (advanced.html)
+       ADVANCED APDA GUIDE  -  NYU PDU (advanced.html)
        ========================================= -->
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
@@ -278,7 +278,7 @@
     <!-- ========== THEORY ========== -->
     <section class="glass-card" id="theory">
       <h3 class="about-header">1) The Theory Playbook (practical, not doctrinal)</h3>
-      <p class="muted">Use theory to preserve fair clash and protect the debate—not to avoid it.</p>
+      <p class="muted">Use theory to preserve fair clash and protect the debate - not to avoid it.</p>
 
       <!-- Tight calls -->
       <article class="expander open">
@@ -292,14 +292,14 @@
           <p><b>Concept.</b> A case is “tight” if, even played perfectly, Opp has no reasonable, weighable path to a ballot.</p>
           <p><b>When to call.</b> LO calls it <i>early</i> and sets a burden story; Gov replies by showing a real Opp path and asking to weigh the debate.</p>
           <ul class="list">
-            <li><b>Opp burden (common):</b> Gov owes a fair, weighable Opp path; they haven’t left one—so fairness governs.</li>
-            <li><b>Gov pushback:</b> There <i>is</i> an Opp route—name it—and invite the judge to weigh.</li>
+            <li><b>Opp burden (common):</b> Gov owes a fair, weighable Opp path; they haven’t left one - so fairness governs.</li>
+            <li><b>Gov pushback:</b> There <i>is</i> an Opp route - name it - and invite the judge to weigh.</li>
           </ul>
           <p class="small"><b>How to argue it.</b> Name the unfair constraint → show why it kills weighability → (Opp) propose a fairness-preserving alternative or (Gov) show Opp’s winnable route.</p>
           <div class="callout mt-6">
             <h4 class="mt-0">Sample tight-block skeletons (Opp)</h4>
             <ul class="list">
-              <li><b>Policy tight:</b> Actor/constraints pre-solve feasibility; no Opp path remains—call tight.</li>
+              <li><b>Policy tight:</b> Actor/constraints pre-solve feasibility; no Opp path remains - call tight.</li>
               <li><b>Moral tight:</b> Standard defined so narrowly it excludes competing values (truism).</li>
               <li><b>Actor-locked tight:</b> Only one actor allowed; all contestable ground ruled out.</li>
             </ul>
@@ -376,7 +376,7 @@
     <!-- ========== FRAMING ========== -->
     <section class="glass-card" id="framing">
       <h3 class="about-header">2) Framing: the lens that decides the ballot</h3>
-      <p><b>Framing</b> is the decision rule you hand the judge: the specific question they must answer to award the ballot (e.g., “Which world better reduces catastrophic risk within five years?”). A strong frame ties to weighing axes (magnitude, probability, timeframe, reversibility) and appears <b>early</b>—PMC/LOC—then dominates rebuttals.</p>
+      <p><b>Framing</b> is the decision rule you hand the judge: the specific question they must answer to award the ballot (e.g., “Which world better reduces catastrophic risk within five years?”). A strong frame ties to weighing axes (magnitude, probability, timeframe, reversibility) and appears <b>early</b> - PMC/LOC - then dominates rebuttals.</p>
       <div class="two-col mt-6">
         <div class="tile">
           <h4>Why it wins</h4>
@@ -462,7 +462,7 @@
       <div class="two-col mt-6">
         <div class="tile">
           <h4>Framing wars & preemption</h4>
-          <p class="muted">State what matters and inoculate: “Common response is X—here’s why it misses the hinge.” Two clean lines now save minutes later.</p>
+          <p class="muted">State what matters and inoculate: “Common response is X - here’s why it misses the hinge.” Two clean lines now save minutes later.</p>
         </div>
         <div class="tile">
           <h4>Time-allocation defaults</h4>
@@ -674,7 +674,7 @@
       <h3 class="about-header">11) Quick reference: protected time, POIs, optionality</h3>
       <ul class="list">
         <li><b>Protected time:</b> No POIs during first 1:00 or last :30 of constructives; no POIs in rebuttals.</li>
-        <li><b>POIs optionality:</b> Optional to offer; optional to accept—choose tactically and courteously.</li>
+        <li><b>POIs optionality:</b> Optional to offer; optional to accept - choose tactically and courteously.</li>
         <li><b>Inclusive timings:</b> Plan to <b>7:30, 8:30, 8:30, 8:30, 4:30, 5:30</b>.</li>
       </ul>
     </section>
@@ -684,7 +684,7 @@
       <h3 class="about-header">12) Equity & Fairness in Advanced Tactics</h3>
       <ul class="list">
         <li>Names & pronouns; respect accommodations; content warnings when appropriate.</li>
-        <li>Don’t win dirty—preserve real clash; avoid abusive designs.</li>
+        <li>Don’t win dirty - preserve real clash; avoid abusive designs.</li>
         <li>Escalate to Equity if needed; model respectful, accessible rooms.</li>
       </ul>
       <div class="mt-6">

--- a/assets/js/forms.js
+++ b/assets/js/forms.js
@@ -83,7 +83,7 @@
         body: fd
       });
       if(res.ok){
-        showToast('Thanks — your message was sent.');
+        showToast('Thanks  -  your message was sent.');
         form.reset();
         // reset submit timers
         const start2 = form.querySelector('input[name="_submit_start"]');

--- a/beginner.html
+++ b/beginner.html
@@ -266,7 +266,7 @@
     <div>
       <h1 class="page-title">Beginner’s Guide to APDA</h1>
       <!-- UPDATED(2): remove "Start here:" -->
-      <p class="page-subtitle">The PDU novice guide — learn the format, speak with confidence, avoid rookie mistakes.</p>
+      <p class="page-subtitle">The PDU novice guide  -  learn the format, speak with confidence, avoid rookie mistakes.</p>
       <div class="cta-banner">
         <a href="practicetools.html" aria-label="Open Practice Tools">Open Practice Tools →</a>
       </div>
@@ -330,7 +330,7 @@
 
     <!-- ===================== GOV VS OPP ===================== -->
     <section class="glass-card" id="gov-opp">
-      <h3 class="about-header">Gov vs Opp — what competing from each side means</h3>
+      <h3 class="about-header">Gov vs Opp  -  what competing from each side means</h3>
       <div class="two-cards">
         <div class="simple-card">
           <h4>Government (Gov)</h4>
@@ -357,7 +357,7 @@
             <div class="label">Do</div>
             <ul class="section-list">
               <li>Group & answer with warrants; find mechanism gaps.</li>
-              <li>Flag tight/spec if needed—keep it minimal and clear.</li>
+              <li>Flag tight/spec if needed - keep it minimal and clear.</li>
               <li>Start the weighing story early.</li>
             </ul>
             <div class="label">Avoid</div>
@@ -374,7 +374,7 @@
 
     <!-- ===================== HOW TO ARGUE ===================== -->
     <section class="glass-card" id="argue">
-      <h3 class="about-header">How to argue — Claim → Warrants → Impacts</h3>
+      <h3 class="about-header">How to argue  -  Claim → Warrants → Impacts</h3>
       <p class="section-intro">
         Every winning point has three parts: the <b>Claim</b> you assert, the <b>Warrants</b> (reasons/mechanism) that make it true, and the <b>Impact</b> (why it matters).
       </p>
@@ -383,13 +383,13 @@
         <li><b>Warrants:</b> why it’s true (incentives, feasibility, cause→effect, actors).</li>
         <li><b>Impacts:</b> so what? who is affected and how?</li>
       </ul>
-      <p class="section-intro" style="margin-top:.8rem;">Then compare: scope & <b>magnitude</b>, <b>probability</b>, <b>timeframe</b>, <b>reversibility</b> — this is <b>weighing</b>.</p>
+      <p class="section-intro" style="margin-top:.8rem;">Then compare: scope & <b>magnitude</b>, <b>probability</b>, <b>timeframe</b>, <b>reversibility</b>  -  this is <b>weighing</b>.</p>
       <p class="note">Stems: “Our mechanism makes X because Y, which means Z.” · “Even if they achieve X, ours wins on magnitude/probability/timeframe because Y.”</p>
 
       <div class="micro" aria-live="polite">
         <div class="label">What’s missing?</div>
         <div class="quiz-row">
-          <button class="quiz-btn" data-q="missing" data-a="warrant">“Ban X will improve outcomes.” (Claim + Impact hinted) — what’s missing?</button>
+          <button class="quiz-btn" data-q="missing" data-a="warrant">“Ban X will improve outcomes.” (Claim + Impact hinted)  -  what’s missing?</button>
         </div>
         <div class="feedback" id="argueFeedback"></div>
       </div>
@@ -402,7 +402,7 @@
 
       <!-- PM -->
       <details class="role-acc" aria-labelledby="role-pm">
-        <summary id="role-pm">Prime Minister (PM) — 7:30</summary>
+        <summary id="role-pm">Prime Minister (PM)  -  7:30</summary>
         <div class="role-body">
           <ul class="section-list">
             <li>Define terms; set fair ground.</li>
@@ -415,7 +415,7 @@
 
       <!-- LO -->
       <details class="role-acc" aria-labelledby="role-lo">
-        <summary id="role-lo">Leader of Opposition (LO) — 8:30</summary>
+        <summary id="role-lo">Leader of Opposition (LO)  -  8:30</summary>
         <div class="role-body">
           <ul class="section-list">
             <li>Frame what matters; take best ground.</li>
@@ -428,7 +428,7 @@
 
       <!-- MG -->
       <details class="role-acc" aria-labelledby="role-mg">
-        <summary id="role-mg">Member of Government (MG) — 8:30</summary>
+        <summary id="role-mg">Member of Government (MG)  -  8:30</summary>
         <div class="role-body">
           <ul class="section-list">
             <li>Defend the center; rebuild with <u>warrants</u>.</li>
@@ -441,7 +441,7 @@
 
       <!-- MO -->
       <details class="role-acc" aria-labelledby="role-mo">
-        <summary id="role-mo">Member of Opposition (MO) — 8:30</summary>
+        <summary id="role-mo">Member of Opposition (MO)  -  8:30</summary>
         <div class="role-body">
           <ul class="section-list">
             <li>Extend Opp’s best offense; ladder voters.</li>
@@ -578,7 +578,7 @@
       <h3 class="about-header">POIs</h3> <!-- UPDATED(12): removed "(short)" -->
       <ul class="section-list">
         <li>Allowed after 1:00 and before the last 1:00 of constructives.</li>
-        <li>Optional to offer and optional to accept — taking one is tactical/courtesy, not mandatory.</li> <!-- UPDATED(12) -->
+        <li>Optional to offer and optional to accept  -  taking one is tactical/courtesy, not mandatory.</li> <!-- UPDATED(12) -->
         <li>Keep them brief and polite; rebuttals do not take POIs.</li>
       </ul>
       <div class="micro" aria-live="polite">
@@ -607,18 +607,18 @@
         <a class="link-chip" href="resources.html">Click here for more resources →</a> <!-- UPDATED(14) -->
       </p>
       <div class="icon-row">
-        <div class="icon-bullet"><span class="ico">✎</span><div><b>Flow</b> — notes tracking claims, warrants, impacts</div></div>
-        <div class="icon-bullet"><span class="ico">⚑</span><div><b>POO</b> — “Point of order”; flags new-in-rebuttal/time issues</div></div>
-        <div class="icon-bullet"><span class="ico">⚖️</span><div><b>Weighing</b> — comparing worlds by magnitude, probability, timeframe, reversibility</div></div>
-        <div class="icon-bullet"><span class="ico">🧭</span><div><b>Framework</b> — what matters and why</div></div>
-        <div class="icon-bullet"><span class="ico">↩︎</span><div><b>Turn</b> — make their argument support your side</div></div>
-        <div class="icon-bullet"><span class="ico">⟲</span><div><b>Extension</b> — carry an argument forward with deeper warrants</div></div>
-        <div class="icon-bullet"><span class="ico">⇣</span><div><b>Collapse</b> — focus on the few arguments that win</div></div>
-        <div class="icon-bullet"><span class="ico">🧱</span><div><b>Tight</b> — unbeatable Gov case; theory calls check this</div></div>
-        <div class="icon-bullet"><span class="ico">🔍</span><div><b>Spec</b> — specific knowledge outside common knowledge/POC</div></div>
-        <div class="icon-bullet"><span class="ico">🗳</span><div><b>RFD</b> — judge’s reason for decision</div></div>
-        <div class="icon-bullet"><span class="ico">⚔️</span><div><b>Clash</b> — where arguments meet</div></div>
-        <div class="icon-bullet"><span class="ico">⬇︎</span><div><b>Drop</b> — unanswered argument</div></div>
+        <div class="icon-bullet"><span class="ico">✎</span><div><b>Flow</b>  -  notes tracking claims, warrants, impacts</div></div>
+        <div class="icon-bullet"><span class="ico">⚑</span><div><b>POO</b>  -  “Point of order”; flags new-in-rebuttal/time issues</div></div>
+        <div class="icon-bullet"><span class="ico">⚖️</span><div><b>Weighing</b>  -  comparing worlds by magnitude, probability, timeframe, reversibility</div></div>
+        <div class="icon-bullet"><span class="ico">🧭</span><div><b>Framework</b>  -  what matters and why</div></div>
+        <div class="icon-bullet"><span class="ico">↩︎</span><div><b>Turn</b>  -  make their argument support your side</div></div>
+        <div class="icon-bullet"><span class="ico">⟲</span><div><b>Extension</b>  -  carry an argument forward with deeper warrants</div></div>
+        <div class="icon-bullet"><span class="ico">⇣</span><div><b>Collapse</b>  -  focus on the few arguments that win</div></div>
+        <div class="icon-bullet"><span class="ico">🧱</span><div><b>Tight</b>  -  unbeatable Gov case; theory calls check this</div></div>
+        <div class="icon-bullet"><span class="ico">🔍</span><div><b>Spec</b>  -  specific knowledge outside common knowledge/POC</div></div>
+        <div class="icon-bullet"><span class="ico">🗳</span><div><b>RFD</b>  -  judge’s reason for decision</div></div>
+        <div class="icon-bullet"><span class="ico">⚔️</span><div><b>Clash</b>  -  where arguments meet</div></div>
+        <div class="icon-bullet"><span class="ico">⬇︎</span><div><b>Drop</b>  -  unanswered argument</div></div>
       </div>
     </section>
 
@@ -753,7 +753,7 @@
           b.setAttribute('aria-pressed','true');
           if(picked.length===orderSeq.length){
             const ok = picked.every((v,i)=> v===orderSeq[i]);
-            orderFeedback.textContent = ok ? 'Nice! That’s the correct speaking order.' : 'Close—try again.';
+            orderFeedback.textContent = ok ? 'Nice! That’s the correct speaking order.' : 'Close - try again.';
             if(!ok){ setTimeout(renderOrderQuiz, 800); }
           }
         });
@@ -779,9 +779,9 @@
     // POOs: scenarios verdicts (valid/invalid + why)
     const pooFeedback = document.getElementById('pooFeedback');
     const pooAnswers = {
-      'poo-pmr-new': ['Valid', 'New argument introduced in a rebuttal (PMR) — POO is appropriate.'],
-      'poo-lor-new': ['Valid', 'New impact added in LOR is new rebuttal material — valid POO.'],
-      'poo-mo-new': ['Invalid', 'POOs target rebuttals/timing issues; MO is a constructive — not a POO.'],
+      'poo-pmr-new': ['Valid', 'New argument introduced in a rebuttal (PMR)  -  POO is appropriate.'],
+      'poo-lor-new': ['Valid', 'New impact added in LOR is new rebuttal material  -  valid POO.'],
+      'poo-mo-new': ['Invalid', 'POOs target rebuttals/timing issues; MO is a constructive  -  not a POO.'],
       'poo-pmr-clarify': ['Invalid', 'Clarifying an existing mechanism isn’t new; usually not POOable.']
     };
     document.querySelectorAll('#rebuttals .quiz-btn[data-q^="poo-"]').forEach(btn=>{
@@ -803,8 +803,8 @@
       btn.addEventListener('click', ()=>{
         const guess = btn.dataset.guess;
         flowFeedback.textContent = (guess==='g2')
-          ? 'Correct: G2 was dropped — extend and weigh it to a voter.'
-          : 'Not quite — the drop was G2. Say it clearly and weigh it.';
+          ? 'Correct: G2 was dropped  -  extend and weigh it to a voter.'
+          : 'Not quite  -  the drop was G2. Say it clearly and weigh it.';
       });
     });
 

--- a/contact.html
+++ b/contact.html
@@ -227,7 +227,7 @@
   <section class="hero-section hero-compact">
     <div class="page-wrap">
       <h1 class="page-title">Contact PDU</h1>
-      <p class="page-subtitle">Reach a person directly—or leave anonymous feedback in seconds.</p>
+      <p class="page-subtitle">Reach a person directly - or leave anonymous feedback in seconds.</p>
     </div>
   </section>
 
@@ -293,7 +293,7 @@
 
       <!-- Success & error banners -->
       <div id="formSuccess" class="banner success" role="status" aria-live="polite">
-        Thank you — your feedback was sent. We appreciate it.
+        Thank you  -  your feedback was sent. We appreciate it.
       </div>
       <div id="formError" class="banner error" role="alert" aria-live="assertive">
         Sorry, something went wrong. Please try again later.
@@ -313,7 +313,7 @@
           <label>
             <span class="helper">Topic (optional)</span>
             <select class="select" name="topic">
-              <option value="">— Choose a topic —</option>
+              <option value=""> -  Choose a topic  - </option>
               <option>General feedback</option>
               <option>Website bug</option>
               <option>Practice/meetings</option>

--- a/equity.html
+++ b/equity.html
@@ -171,7 +171,7 @@
     <section class="glass-card" id="tldr">
       <h3 class="about-header">TL;DR & Scope</h3>
       <p class="about-preview">
-        Equity is a core value of APDA—and of PDU. Debate can be fast, competitive, and emotionally charged. Our goal is a space where everyone can challenge ideas without harming people. This policy applies to meetings, scrims, tournaments, travel, socials, and all online team spaces.
+        Equity is a core value of APDA - and of PDU. Debate can be fast, competitive, and emotionally charged. Our goal is a space where everyone can challenge ideas without harming people. This policy applies to meetings, scrims, tournaments, travel, socials, and all online team spaces.
       </p>
       <div class="cta-row">
         <a class="link-chip" href="#reporting">Report a concern →</a>
@@ -216,7 +216,7 @@
     <section class="glass-card" id="conduct">
       <h3 class="about-header">Sportsmanship & Conduct</h3>
       <p class="about-preview">
-        Intimidation, insults, condescension, mocking accents, misgendering, or hostile behavior toward debaters or judges is not allowed—during or after rounds, in halls, group chats, or social events.
+        Intimidation, insults, condescension, mocking accents, misgendering, or hostile behavior toward debaters or judges is not allowed - during or after rounds, in halls, group chats, or social events.
       </p>
       <ul class="section-list">
         <li><strong>Not allowed:</strong> Personal attacks (“You’re stupid”), sarcastic belittling of a speaker, repeated mispronouncing of a name after correction.</li>
@@ -228,7 +228,7 @@
     <section class="glass-card" id="tournament-equity">
       <h3 class="about-header">Tournament Equity</h3>
       <p class="about-preview">
-        Each tournament announces its Equity Policy and the Equity Team at opening assembly. Follow host rules for reporting and resolution. If in doubt, ask the Equity Team or a PDU officer—immediately.
+        Each tournament announces its Equity Policy and the Equity Team at opening assembly. Follow host rules for reporting and resolution. If in doubt, ask the Equity Team or a PDU officer - immediately.
       </p>
       <div class="cta-row">
         <a class="link-chip" href="tournaments.html">See Tournament Info Docs (TIDs) →</a>
@@ -277,7 +277,7 @@
     <section class="glass-card" id="judging">
       <h3 class="about-header">Judging</h3>
       <p class="about-preview">
-        Judges safeguard equity in every round. Ballots must reflect the arguments made—not a speaker’s identity, style, or reputation.
+        Judges safeguard equity in every round. Ballots must reflect the arguments made - not a speaker’s identity, style, or reputation.
       </p>
       <ul class="section-list">
         <li>Evaluate only comparative analysis presented in round.</li>
@@ -311,7 +311,7 @@
         <li>Pair thoughtfully and support newer members.</li>
         <li>Choose cases that challenge ideas without targeting identities.</li>
       </ul>
-      <p class="about-preview" style="margin-top:.75rem;">Questions or concerns? Reach out to the Equity Officer or the Operations Director—earlier is better.</p>
+      <p class="about-preview" style="margin-top:.75rem;">Questions or concerns? Reach out to the Equity Officer or the Operations Director - earlier is better.</p>
       <div class="cta-row">
         <a class="link-chip" href="leadership.html">Leadership →</a>
         <a class="link-chip" href="about.html#meetings">Meetings →</a>

--- a/index.html
+++ b/index.html
@@ -297,7 +297,7 @@
   <!-- Identity chip -->
   <section class="week-strip">
     <ul class="week-pills">
-      <li class="chip">NYU Debate — Parliamentary Debate Union</li>
+      <li class="chip">NYU Debate  -  Parliamentary Debate Union</li>
     </ul>
   </section>
 
@@ -457,7 +457,7 @@
       </div>
       <div class="highlight-body">
         <h3 class="about-header">Recent Highlights</h3>
-        <p>Quarterfinals at Princeton + Top 10 Speaks. Big shoutout to our novice squads — huge strides this month.</p>
+        <p>Quarterfinals at Princeton + Top 10 Speaks. Big shoutout to our novice squads  -  huge strides this month.</p>
         <a class="link-chip" href="tournaments.html">See results & recaps →</a>
       </div>
     </section>
@@ -465,7 +465,7 @@
     <!-- Equity preview -->
     <section class="glass-card reveal">
       <h3 class="about-header">Equity</h3>
-      <p>We debate ideas, not identities. PDU is committed to respectful, inclusive competition — at meetings and on the circuit.</p>
+      <p>We debate ideas, not identities. PDU is committed to respectful, inclusive competition  -  at meetings and on the circuit.</p>
       <div class="cta-row">
         <a class="link-chip" href="equity.html">Read our equity policy →</a>
       </div>
@@ -475,7 +475,7 @@
   <!-- Footer CTA band -->
   <section class="cta-band">
     <h3>Ready to try a meeting?</h3>
-    <p>Open to all NYU students — no experience needed.</p>
+    <p>Open to all NYU students  -  no experience needed.</p>
     <a class="btn-primary" href="join.html">Join us this week</a>
   </section>
 
@@ -589,7 +589,7 @@
       const ss=s%60;
       const weekday=target.toLocaleDateString('en-US',{timeZone:'America/New_York', weekday:'long'});
       const dateStr=target.toLocaleString('en-US',{timeZone:'America/New_York', month:'short', day:'numeric'});
-      cdEl.textContent=`Next meeting: ${weekday} ${dateStr} · 7:00 PM ET — in ${d}d ${h}h ${m}m ${ss}s`;
+      cdEl.textContent=`Next meeting: ${weekday} ${dateStr} · 7:00 PM ET  -  in ${d}d ${h}h ${m}m ${ss}s`;
     }
     tick(); setInterval(tick,1000);
   </script>

--- a/join.html
+++ b/join.html
@@ -299,7 +299,7 @@
   <section class="hero-section hero-compact" id="joinHero">
     <div>
       <h1 class="page-title">Join the Parliamentary Debate Union</h1>
-      <p class="page-subtitle">Open to all NYU students — drop in Mondays or Wednesdays, 7–9 PM. Move at your own pace.</p>
+      <p class="page-subtitle">Open to all NYU students  -  drop in Mondays or Wednesdays, 7–9 PM. Move at your own pace.</p>
     </div>
   </section>
 
@@ -318,7 +318,7 @@
       <div class="cta-row">
         <a class="link-chip" href="mailing-list.html">Join the mailing list →</a>
       </div>
-      <p class="note" style="margin-top:.5rem;">(Placeholder link—wire it to your actual list when ready.)</p>
+      <p class="note" style="margin-top:.5rem;">(Placeholder link - wire it to your actual list when ready.)</p>
     </section>
 
     <!-- Big Beginners CTA -->
@@ -355,14 +355,14 @@
 
       <div class="two-col" style="margin-top:.75rem;">
         <div>
-          <p class="subhead">Monday — Lesson Meeting</p>
+          <p class="subhead">Monday  -  Lesson Meeting</p>
           <ul class="section-list">
             <li><strong>Lecture:</strong> Focused skill-building.</li>
             <li><strong>Engagement:</strong> Short activities to check understanding.</li>
-            <li><strong>Practice Rounds:</strong> Try when you’re ready—no pressure.</li>
+            <li><strong>Practice Rounds:</strong> Try when you’re ready - no pressure.</li>
           </ul>
 
-          <p class="subhead" style="margin-top:1rem;">Wednesday — Training Meeting</p>
+          <p class="subhead" style="margin-top:1rem;">Wednesday  -  Training Meeting</p>
           <ul class="section-list">
             <li><strong>Practice Round:</strong> Full scrim(s) with feedback.</li>
             <li><strong>Workshopping:</strong> Case-building with senior members and the board.</li>
@@ -431,7 +431,7 @@
           <div class="cta-row"><a class="link-chip" href="calendar.html">Open calendar →</a></div>
         </div>
       </div>
-      <p class="note" style="margin-top:.5rem;">These are placeholders—update the bullets monthly (no weekly upkeep needed).</p>
+      <p class="note" style="margin-top:.5rem;">These are placeholders - update the bullets monthly (no weekly upkeep needed).</p>
     </section>
 
     <!-- Partners & Assignments -->
@@ -441,9 +441,9 @@
         There’s no formal permanent matching process. <strong>Partners are requested or assigned in person on a per-tournament basis.</strong>
       </p>
       <ul class="section-list">
-        <li><strong>Have a preferred partner?</strong> Tell us at meetings—we’ll try to honor it based on availability and roster size.</li>
+        <li><strong>Have a preferred partner?</strong> Tell us at meetings - we’ll try to honor it based on availability and roster size.</li>
         <li><strong>Flexible or new?</strong> We’ll pair you with someone compatible (schedule, goals, experience).</li>
-        <li><strong>Not a fit?</strong> Partnerships can change between events—it’s normal.</li>
+        <li><strong>Not a fit?</strong> Partnerships can change between events - it’s normal.</li>
       </ul>
       <div class="cta-row">
         <a class="link-chip" href="tournaments.html">How tournaments work →</a>
@@ -468,15 +468,15 @@
       </details>
       <details>
         <summary>Time?</summary>
-        <p class="about-preview" style="margin-top:.5rem;">Meetings are Mon/Wed 7–9 PM. Join when you can—move at your own pace. Travel is optional.</p>
+        <p class="about-preview" style="margin-top:.5rem;">Meetings are Mon/Wed 7–9 PM. Join when you can - move at your own pace. Travel is optional.</p>
       </details>
       <details>
         <summary>Gear?</summary>
-        <p class="about-preview" style="margin-top:.5rem;">Bring a laptop or notebook if you like—nothing special required.</p>
+        <p class="about-preview" style="margin-top:.5rem;">Bring a laptop or notebook if you like - nothing special required.</p>
       </details>
       <details>
         <summary>Accessibility & culture?</summary>
-        <p class="about-preview" style="margin-top:.5rem;">Tell us your access needs (pace, seating, breaks)—we’ll work with you. We debate ideas, not identities. Read our <a href="equity.html" class="link-chip" style="padding:.2rem .6rem; border-radius:999px;">Equity policy →</a></p>
+        <p class="about-preview" style="margin-top:.5rem;">Tell us your access needs (pace, seating, breaks) - we’ll work with you. We debate ideas, not identities. Read our <a href="equity.html" class="link-chip" style="padding:.2rem .6rem; border-radius:999px;">Equity policy →</a></p>
       </details>
     </section>
   </main>

--- a/judging.html
+++ b/judging.html
@@ -301,7 +301,7 @@
   <section class="hero-section hero-compact judge-hero">
     <div>
       <h1 class="page-title">Judging at PDU</h1>
-      <p class="page-subtitle">Judging keeps our team on the circuit—your perspective makes rounds fair and helps novices grow. PDU strongly encourages members to judge.</p>
+      <p class="page-subtitle">Judging keeps our team on the circuit - your perspective makes rounds fair and helps novices grow. PDU strongly encourages members to judge.</p>
       <div class="hero-cta-row">
         <a class="link-chip" href="tournaments.html">Judge at the next tournament →</a>
         <a class="link-chip" href="calendar.html">Calendar →</a>
@@ -343,11 +343,11 @@
         </div>
         <div class="tile">
           <h4>For Debaters</h4>
-          <p class="muted">Clear, comparative feedback accelerates growth—especially for novices.</p>
+          <p class="muted">Clear, comparative feedback accelerates growth - especially for novices.</p>
         </div>
         <div class="tile">
           <h4>For You</h4>
-          <p class="muted">Judging sharpens flow, weighing, and RFD craft—skills that also make you a stronger speaker.</p>
+          <p class="muted">Judging sharpens flow, weighing, and RFD craft - skills that also make you a stronger speaker.</p>
         </div>
       </div>
     </section>
@@ -432,7 +432,7 @@
         <div class="exp-body">
           <ul class="list">
             <li><b>Inclusive timings:</b> plan speeches to <b>7:30, 8:30, 8:30, 8:30, 4:30, 5:30</b>.</li>
-            <li><b>Protected time:</b> first 1:00 and last :30 of constructives—no POIs.</li>
+            <li><b>Protected time:</b> first 1:00 and last :30 of constructives - no POIs.</li>
             <li>Signal time consistently (verbal cue or knock) and stay neutral.</li>
             <li><a class="chip" href="practicetools.html#timer">Use the site Timer →</a></li>
           </ul>
@@ -543,7 +543,7 @@
         <!-- Checklist -->
         <div class="kit-card kit-check">
           <h4>Judge Checklist</h4>
-          <p class="muted">Before / During / After — quick sanity check you can print or save.</p>
+          <p class="muted">Before / During / After  -  quick sanity check you can print or save.</p>
           <div class="mini-controls">
             <button class="btn" id="dlChecklist">Download (.txt)</button>
             <a class="chip" href="practicetools.html#timer">Open Timer →</a>
@@ -622,7 +622,7 @@
       <div class="two-col">
         <div class="tile">
           <h4>Do I need prior experience?</h4>
-          <p class="muted">No. We’ll get you started—use the checklist, Ballot Builder, and tools above.</p>
+          <p class="muted">No. We’ll get you started - use the checklist, Ballot Builder, and tools above.</p>
         </div>
         <div class="tile">
           <h4>What if I’m unsure about a rule?</h4>
@@ -634,7 +634,7 @@
         </div>
         <div class="tile">
           <h4>Can I judge if I’m competing?</h4>
-          <p class="muted">Often yes between rounds—confirm with the Board and the tournament tab room.</p>
+          <p class="muted">Often yes between rounds - confirm with the Board and the tournament tab room.</p>
         </div>
       </div>
     </section>
@@ -779,21 +779,21 @@ AFTER
       const fbG = $('rfFbGov').value.trim();
       const fbO = $('rfFbOpp').value.trim();
 
-      const text = `RFD — Winner: ${winner}
+      const text = `RFD  -  Winner: ${winner}
 
 Round focus: ${focus}
 
 Key issues:
-${issues || '—'}
+${issues || ' - '}
 
 Why ${winner} wins (comparative, weighed):
-${why || '—'}
+${why || ' - '}
 
 Feedback to Government:
-${fbG || '—'}
+${fbG || ' - '}
 
 Feedback to Opposition:
-${fbO || '—'}
+${fbO || ' - '}
 `;
       $('rfOut').value = text;
     }
@@ -809,19 +809,19 @@ ${fbO || '—'}
 
     // POO Quiz scenarios
     const scenarios = [
-      {q:'PMR introduces a brand-new impact.', a:'Valid — new in rebuttal. Keep the ruling brief.', verdict:'valid'},
-      {q:'MO makes a weak characterization; LO stands to POO mid-speech.', a:'Invalid — POOs are for procedure (e.g., new in rebuttal, timing), not for disputing substance in constructives.', verdict:'invalid'},
-      {q:'LOR continues well past 5:30 and ignores time signals.', a:'Valid — significant timing issue. Make a quick ruling and keep the round moving.', verdict:'valid'},
-      {q:'Speaker refuses all POIs throughout their constructive.', a:'Invalid — offering/accepting POIs is optional. Note tactically, not procedurally.', verdict:'invalid'},
-      {q:'MG adds a brand-new advantage.', a:'Invalid — new material is allowed in constructives; evaluate it substantively.', verdict:'invalid'},
-      {q:'PM repeatedly takes POIs during protected time.', a:'Valid procedural reminder — enforce protected time; then proceed.', verdict:'valid'}
+      {q:'PMR introduces a brand-new impact.', a:'Valid  -  new in rebuttal. Keep the ruling brief.', verdict:'valid'},
+      {q:'MO makes a weak characterization; LO stands to POO mid-speech.', a:'Invalid  -  POOs are for procedure (e.g., new in rebuttal, timing), not for disputing substance in constructives.', verdict:'invalid'},
+      {q:'LOR continues well past 5:30 and ignores time signals.', a:'Valid  -  significant timing issue. Make a quick ruling and keep the round moving.', verdict:'valid'},
+      {q:'Speaker refuses all POIs throughout their constructive.', a:'Invalid  -  offering/accepting POIs is optional. Note tactically, not procedurally.', verdict:'invalid'},
+      {q:'MG adds a brand-new advantage.', a:'Invalid  -  new material is allowed in constructives; evaluate it substantively.', verdict:'invalid'},
+      {q:'PM repeatedly takes POIs during protected time.', a:'Valid procedural reminder  -  enforce protected time; then proceed.', verdict:'valid'}
     ];
     const quizWrap = document.getElementById('pooQuiz');
     function renderQuiz(){
       quizWrap.innerHTML = scenarios.map((s,i)=>`
         <div class="quiz-chip" data-i="${i}" tabindex="0" aria-expanded="false">
           <div><b>Scenario:</b> ${s.q}</div>
-          <div class="answer"><b>${s.verdict.toUpperCase()}</b> — ${s.a}</div>
+          <div class="answer"><b>${s.verdict.toUpperCase()}</b>  -  ${s.a}</div>
         </div>
       `).join('');
       quizWrap.querySelectorAll('.quiz-chip').forEach(ch=>{

--- a/leadership.html
+++ b/leadership.html
@@ -337,7 +337,7 @@
               data-role="President"
               data-img="placeholder.jpg"
               data-email="rrs6697@nyu.edu"
-              data-bio="Rayan coordinates team strategy, outreach, and the competitive calendar—aligning training, travel, and culture across the season.">
+              data-bio="Rayan coordinates team strategy, outreach, and the competitive calendar - aligning training, travel, and culture across the season.">
         <div class="leader-media"><img loading="lazy" src="placeholder.jpg" alt="Portrait of Rayan Sheikh"></div>
         <div class="leader-info">
           <h3 class="leader-name">Rayan Sheikh</h3>
@@ -367,7 +367,7 @@
               data-role="Operations"
               data-img="your-photo.jpg"
               data-email="mac1021@nyu.edu"
-              data-bio="Travel, logistics, rosters, and TIDs—your point of contact for sign-ups, itineraries, and attendance.">
+              data-bio="Travel, logistics, rosters, and TIDs - your point of contact for sign-ups, itineraries, and attendance.">
         <div class="leader-media"><img loading="lazy" src="your-photo.jpg" alt="Portrait of Marcel Cato"></div>
         <div class="leader-info">
           <h3 class="leader-name">Marcel Cato</h3>
@@ -397,7 +397,7 @@
               data-role="Equity"
               data-img="placeholder.jpg"
               data-email="placeholder@nyu.edu"
-              data-bio="Confidential reports, team culture, and coordination with tournament Equity—ensuring challenging debate without harm.">
+              data-bio="Confidential reports, team culture, and coordination with tournament Equity - ensuring challenging debate without harm.">
         <span class="badge-equity">★ Equity</span>
         <div class="leader-media"><img loading="lazy" src="placeholder.jpg" alt="Portrait of Dara Adebanjo"></div>
         <div class="leader-info">
@@ -413,7 +413,7 @@
               data-role="Communications"
               data-img="placeholder.jpg"
               data-email="placeholder@nyu.edu"
-              data-bio="Mailing list, announcements, and social updates—keeping members and partners in the loop.">
+              data-bio="Mailing list, announcements, and social updates - keeping members and partners in the loop.">
         <div class="leader-media"><img loading="lazy" src="placeholder.jpg" alt="Portrait of Dedra Annakie"></div>
         <div class="leader-info">
           <h3 class="leader-name">Dedra Annakie</h3>

--- a/members.html
+++ b/members.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Members Dashboard | NYU PDU</title>
-  <meta name="description" content="Members Dashboard — your go-to for PDU this semester: meetings, tournaments, resources, announcements, and quick links." />
+  <meta name="description" content="Members Dashboard  -  your go-to for PDU this semester: meetings, tournaments, resources, announcements, and quick links." />
   <link rel="icon" type="image/png" href="PDUVIOLETWHITE.png">
 
   <!-- Global site styles / fonts for cohesion -->
@@ -241,12 +241,12 @@
 
   <main>
     <div class="dash-container">
-      <!-- ===== THIS MONTH AT PDU — SEPTEMBER ===== -->
+      <!-- ===== THIS MONTH AT PDU  -  SEPTEMBER ===== -->
       <section class="section" id="month">
         <div class="dash-grid">
           <!-- A) Calendar embed card -->
           <div class="dash-card accent-success span-7">
-            <h3 class="about-header">This Month at PDU — <span>September 2025</span></h3>
+            <h3 class="about-header">This Month at PDU  -  <span>September 2025</span></h3>
             <p class="muted">Room locations and last-minute changes live on the calendar.</p>
 
             <div style="margin-top:.5rem; border-radius:12px; overflow:hidden; border:1px solid rgba(255,255,255,.18);">
@@ -266,7 +266,7 @@
 
           <!-- B) September tournaments overview (sharper separation + bigger headers) -->
           <div class="dash-card accent-warn span-5">
-            <h3 class="about-header" style="margin-top:.1rem;">September Tournaments — Overview</h3>
+            <h3 class="about-header" style="margin-top:.1rem;">September Tournaments  -  Overview</h3>
             <p class="about-preview" style="margin-bottom:.75rem;">
               Expect 2–3 weekend tournaments. Sign-ups open ~10–12 days prior; pairs posted the week-of; travel covered.
             </p>
@@ -327,7 +327,7 @@
           <div class="dash-card accent-warn span-4">
             <h4>November</h4>
             <ul>
-              <li>Busy travel window — plan ahead</li>
+              <li>Busy travel window  -  plan ahead</li>
               <li>Rooming notes on Calendar events</li>
             </ul>
             <div class="cta-row"><a class="link-chip" href="tournaments.html#november">See slate →</a></div>
@@ -336,7 +336,7 @@
           <div class="dash-card accent-rose span-4">
             <h4>December</h4>
             <ul>
-              <li>Finals period — limited meetings</li>
+              <li>Finals period  -  limited meetings</li>
               <li>Optional winter opens</li>
             </ul>
             <div class="cta-row"><a class="link-chip" href="tournaments.html#december">See slate →</a></div>
@@ -368,7 +368,7 @@
 
           <div class="dash-card accent-info span-4">
             <h4>Practice Tools</h4>
-            <p class="about-preview">Timers, flashcards, drills, prompts—solo or with a partner.</p>
+            <p class="about-preview">Timers, flashcards, drills, prompts - solo or with a partner.</p>
             <div class="cta-row"><a class="link-chip" href="practicetools.html">Practice Tools →</a></div>
           </div>
 
@@ -523,7 +523,7 @@
       const ss=s%60;
       const weekday=target.toLocaleDateString('en-US',{timeZone:'America/New_York', weekday:'long'});
       const dateStr=target.toLocaleString('en-US',{timeZone:'America/New_York', month:'short', day:'numeric'});
-      cdEl.textContent=`Next meeting: ${weekday} ${dateStr} · 7:00 PM ET — in ${d}d ${h}h ${m}m ${ss}s`;
+      cdEl.textContent=`Next meeting: ${weekday} ${dateStr} · 7:00 PM ET  -  in ${d}d ${h}h ${m}m ${ss}s`;
     }
     tick(); setInterval(tick,1000);
   </script>

--- a/practicetools.html
+++ b/practicetools.html
@@ -485,8 +485,8 @@
           <textarea id="cbMech" class="textarea" placeholder="Specify who acts, incentives, feasibility, enforcement."></textarea>
         </label>
         <label>Reasons (2–4), with warrants → impacts
-          <textarea id="cbReasons" class="textarea" placeholder="Reason #1 — warrants → impact
-Reason #2 — warrants → impact"></textarea>
+          <textarea id="cbReasons" class="textarea" placeholder="Reason #1  -  warrants → impact
+Reason #2  -  warrants → impact"></textarea>
         </label>
         <label>Comparative world (why your world is better)
           <textarea id="cbComp" class="textarea" placeholder="Explain why your world is strictly better than the status quo."></textarea>
@@ -574,10 +574,10 @@ Reason #2 — warrants → impact"></textarea>
         <div class="tool-card examples">
           <h4>Examples</h4>
           <ul class="mini-list">
-            <li>“Even if they get <i>uptake</i>, our policy reaches <b>more people sooner</b> — higher magnitude, faster timeframe.”</li>
+            <li>“Even if they get <i>uptake</i>, our policy reaches <b>more people sooner</b>  -  higher magnitude, faster timeframe.”</li>
             <li>“Their harm is <i>low-probability</i> and reversible; ours is <b>likely</b> and hard to reverse.”</li>
           </ul>
-          <p class="muted">Tip: speak the weighing line twice—when introducing an argument and again in rebuttal.</p>
+          <p class="muted">Tip: speak the weighing line twice - when introducing an argument and again in rebuttal.</p>
         </div>
       </div>
     </section>
@@ -655,7 +655,7 @@ Reason #2 — warrants → impact"></textarea>
               </select>
               <button class="btn" id="pooCheck">Check</button>
             </div>
-            <div id="pooVerdict" class="chip" aria-live="polite">—</div>
+            <div id="pooVerdict" class="chip" aria-live="polite"> - </div>
           </div>
         </div>
       </div>
@@ -934,12 +934,12 @@ Reason #2 — warrants → impact"></textarea>
     document.querySelectorAll('button[data-poc]').forEach(btn=>{
       btn.addEventListener('click', ()=>{
         const map = {
-          defs: 'POC: Could you clarify how you’re defining [term]? — A:',
-          actors: 'POC: Who is the actor implementing this? — A:',
-          mech: 'POC: How will this be enforced or implemented in practice? — A:',
-          scope: 'POC: What is the scope/limit of this policy? — A:'
+          defs: 'POC: Could you clarify how you’re defining [term]?  -  A:',
+          actors: 'POC: Who is the actor implementing this?  -  A:',
+          mech: 'POC: How will this be enforced or implemented in practice?  -  A:',
+          scope: 'POC: What is the scope/limit of this policy?  -  A:'
         };
-        const line = map[btn.dataset.poc] || 'POC: — A:';
+        const line = map[btn.dataset.poc] || 'POC:  -  A:';
         pocLog.value = (pocLog.value ? pocLog.value + '\n' : '') + line;
         pocLog.focus();
         pocLog.setSelectionRange(pocLog.value.length, pocLog.value.length);
@@ -1013,7 +1013,7 @@ Reason #2 — warrants → impact"></textarea>
     document.getElementById('clearFlow').addEventListener('click', ()=> flowBody.innerHTML='');
 
     /* ==========================================================
-      CASE BUILDER — Expanded Lint
+      CASE BUILDER  -  Expanded Lint
     ========================================================== */
     const cbIds = ['cbRes','cbDefs','cbMech','cbReasons','cbComp'];
     const cb = id => document.getElementById(id);
@@ -1045,7 +1045,7 @@ Reason #2 — warrants → impact"></textarea>
       if(!text.reasons.trim()){ warnings.push('List 2–4 reasons with warrants → impacts.'); setFieldWarn('cbReasons', true); } else setFieldWarn('cbReasons', false);
 
       if(/always|never|obviously|undeniably|by definition|tautology|truism/.test(text.res)){
-        warnings.push('Resolution language risks truism/tight—soften absolutes or broaden contestability.');
+        warnings.push('Resolution language risks truism/tight - soften absolutes or broaden contestability.');
       }
 
       if(/esoteric|obscure|little-known|insider|technical detail/.test(text.reasons) || /specific year|dataset|secret/.test(text.reasons)){
@@ -1053,7 +1053,7 @@ Reason #2 — warrants → impact"></textarea>
       }
 
       if(!/(enforce|implement|agency|actor|government|university|company|mechanism|incentive|fund|budget|pilot|rollout)/.test(text.mech)){
-        warnings.push('Mechanism may be thin — include who pays/implements and why it works.');
+        warnings.push('Mechanism may be thin  -  include who pays/implements and why it works.');
       }
 
       const reasonCount = (raw.reasons.match(/(^|\n)\s*reason/gi) || []).length;
@@ -1072,7 +1072,7 @@ Reason #2 — warrants → impact"></textarea>
         cbLint.querySelector('.title').textContent = 'Lint:';
       } else {
         cbLint.className = 'lint ok';
-        cbLint.querySelector('.title').textContent = 'Lint: Looks good — clear, fair, and debatable.';
+        cbLint.querySelector('.title').textContent = 'Lint: Looks good  -  clear, fair, and debatable.';
         cbLintList.innerHTML = '';
       }
     }
@@ -1154,7 +1154,7 @@ Weighing narrative to PMR
     const pick = arr => arr[Math.floor(Math.random()*arr.length)];
 
     byId('rebNew').addEventListener('click', ()=> byId('rebPrompt').textContent = pick(rebPrompts));
-    byId('wghNew').addEventListener('click', ()=> byId('wghPrompt').textContent = `Weigh on: ${pick(wghAxes)} — versus their best impact.`);
+    byId('wghNew').addEventListener('click', ()=> byId('wghPrompt').textContent = `Weigh on: ${pick(wghAxes)}  -  versus their best impact.`);
     byId('poiNew').addEventListener('click', ()=> byId('poiPrompt').textContent = pick(poiPrompts));
 
     let drillTick=null, drillRemain=0;
@@ -1211,7 +1211,7 @@ Weighing narrative to PMR
       sections.push(grab('pTime','pTimeName'));
       sections.push(grab('pPOO','pPOOName'));
       sections.push(grab('pCase','pCaseName'));
-      return `Partner pact — ${sections.join(' · ')}. Max two passed notes (warrant; weighing).`;
+      return `Partner pact  -  ${sections.join(' · ')}. Max two passed notes (warrant; weighing).`;
     }
     document.getElementById('pGen').addEventListener('click', ()=>{
       const t = document.getElementById('pText'); t.value = pactLine();
@@ -1242,7 +1242,7 @@ Weighing narrative to PMR
       } else if(type==='clarify'){
         msg = 'Usually not POO: clarifying an existing line is typically fine.';
       } else {
-        msg = '—';
+        msg = ' - ';
       }
       verdict.textContent = msg;
     });

--- a/resources.html
+++ b/resources.html
@@ -256,7 +256,7 @@
   <section class="hero-section hero-compact res-hero">
     <div>
       <h1 class="page-title">Resources Library</h1>
-      <p class="page-subtitle">Templates, explainers, and curated links for NYU PDU novices—skim, save, and get back to practice.</p>
+      <p class="page-subtitle">Templates, explainers, and curated links for NYU PDU novices - skim, save, and get back to practice.</p>
       <div class="hero-cta-row">
         <a class="link-chip" href="beginner.html">Beginner Guide →</a>
         <a class="link-chip" href="practicetools.html">Practice Tools →</a>
@@ -748,7 +748,7 @@
     $('freshCards').innerHTML = fresh || `<div class="muted">We’ll spotlight new items here.</div>`;
 
     /* ==========================================================
-      TEMPLATES — DOWNLOADS & BUNDLE
+      TEMPLATES  -  DOWNLOADS & BUNDLE
     ========================================================== */
     function saveText(name, text){
       const blob = new Blob([text], {type:'text/plain'});
@@ -791,7 +791,7 @@ Weighing narrative to PMR
 `;
     }
     function rebuttalChecklist(){
-      return `REBUTTAL CHECKLIST — LOR / PMR
+      return `REBUTTAL CHECKLIST  -  LOR / PMR
 
 [ ] Collapse: pick the winning path
 [ ] Explicit weighing (mag/prob/time/reversibility)
@@ -822,12 +822,12 @@ Policy: Max two passed notes (missing warrant; weighing line). Simple hand signa
     function timelineTxt(){
       return `ROUND TIMELINE (with grace)
 
-PMC — 7:30
-LOC — 8:30
-MG  — 8:30
-MO  — 8:30
-LOR — 4:30
-PMR — 5:30
+PMC  -  7:30
+LOC  -  8:30
+MG   -  8:30
+MO   -  8:30
+LOR  -  4:30
+PMR  -  5:30
 
 Protected time: first 1:00 and last :30 of constructives. POIs optional to offer and accept.
 `;
@@ -856,7 +856,7 @@ Protected time: first 1:00 and last :30 of constructives. POIs optional to offer
     });
 
     /* ==========================================================
-      GLOSSARY — DATA & SEARCH
+      GLOSSARY  -  DATA & SEARCH
     ========================================================== */
     const GLOSSARY = [
       ['APDA','American Parliamentary Debate Association; the 2v2 circuit we compete in.'],
@@ -887,7 +887,7 @@ Protected time: first 1:00 and last :30 of constructives. POIs optional to offer
       ['Tight call','Opp claims the case is unfair/unwinnable; judge applies a fairness test.'],
       ['Spec (specific knowledge)','Niche facts not reasonably shared; avoid relying on them without grounding.'],
       ['Speaks','Speaker points awarded by judges (see APDA Speaker Scale).'],
-      ['RFD','Reason for Decision — judge’s explanation.'],
+      ['RFD','Reason for Decision  -  judge’s explanation.'],
       ['Break','Advance to elimination rounds.'],
       ['Tab','Tournament tabulation (pairings, results).'],
       ['Pro-Am','Tournament/round where a varsity partners with a novice (convention varies).'],

--- a/style.css
+++ b/style.css
@@ -375,7 +375,7 @@ section[id] .about-header, section[id] h3, section[id] h4{ scroll-margin-top:96p
   margin-top:.3rem;
 }
 
-/* ================= Contents Drawer (About) — locked in ================= */
+/* ================= Contents Drawer (About)  -  locked in ================= */
 .toc-drawer{
   position:fixed; top:calc(var(--nav-height) + 10px); left:0; bottom:30px; width:280px;
   transform:translateX(-100%); transition:transform .35s ease; z-index:1085;

--- a/tournaments.html
+++ b/tournaments.html
@@ -17,7 +17,7 @@
     <meta property="og:url" content="https://nyupdu.github.io/tournaments.html" />
     <meta property="og:image" content="https://nyupdu.github.io/PDULOGO_Trans.png" />
 
-    <!-- Page-local styles (no TOC styles here—uses the same global classes as About) -->
+    <!-- Page-local styles (no TOC styles here - uses the same global classes as About) -->
   <style>
     .page-wrap { width: 95%; max-width: 1100px; margin: 0 auto; }
     .cta-row { display:flex; flex-wrap:wrap; gap:.5rem; margin-top:.6rem; }
@@ -268,7 +268,7 @@
             <a class="link-chip" href="calendar.html">Add/See on Calendar →</a>
             <a class="link-chip" href="https://drive.google.com/drive/folders/1SIot57czQp_hxY6Bx38I_SN4deVhbvDo?usp=drive_link" target="_blank" rel="noopener">TID (Drive) →</a>
           </div>
-          <p class="note">Sign up to debate <em>or</em> judge — choose your role in the form.</p>
+          <p class="note">Sign up to debate <em>or</em> judge  -  choose your role in the form.</p>
         </div>
 
         <aside class="feature-right">
@@ -310,7 +310,7 @@
             <a class="link-chip" href="calendar.html">Calendar →</a>
             <a class="link-chip" href="https://drive.google.com/drive/folders/1SIot57czQp_hxY6Bx38I_SN4deVhbvDo?usp=drive_link" target="_blank" rel="noopener">TID →</a>
           </div>
-          <p class="note">Sign up to debate <em>or</em> judge — choose your role in the form.</p>
+          <p class="note">Sign up to debate <em>or</em> judge  -  choose your role in the form.</p>
         </article>
 
         <!-- Card 2: Tentative -->
@@ -391,7 +391,7 @@
     <section class="glass-card reveal" id="judging">
       <h3 class="about-header">Judging</h3>
       <p class="about-preview">
-        Great rounds need great judges. You can sign up to judge using the same interest form as debaters—just select “Judge.” We’ll provide a quick briefing, a timer, and a flow sheet. No prior APDA experience required.
+        Great rounds need great judges. You can sign up to judge using the same interest form as debaters - just select “Judge.” We’ll provide a quick briefing, a timer, and a flow sheet. No prior APDA experience required.
       </p>
       <ul class="section-list">
         <li><strong>Before:</strong> Read the case statement, note any CWs, track protected time.</li>
@@ -441,7 +441,7 @@
     <section class="glass-card reveal" id="tids">
       <h3 class="about-header">Tournament Info Documents (TIDs)</h3>
       <p class="about-preview">
-        Each tournament has a TID—a single source of truth with timelines, travel, lodging, maps, schedules, packing lists, equity reminders, and contacts.
+        Each tournament has a TID - a single source of truth with timelines, travel, lodging, maps, schedules, packing lists, equity reminders, and contacts.
         We’ll publish each TID to a public Drive folder once the roster is set.
       </p>
       <div class="cta-row">
@@ -466,7 +466,7 @@
       </details>
       <details>
         <summary>Absence letters</summary>
-        <p class="about-preview" style="margin-top:.5rem;">Need a letter for professors? Contact the Operations Director—we’ll coordinate.</p>
+        <p class="about-preview" style="margin-top:.5rem;">Need a letter for professors? Contact the Operations Director - we’ll coordinate.</p>
       </details>
       <details>
         <summary>Day-of updates</summary>
@@ -479,9 +479,9 @@
       <h3 class="about-header">Partners & Roles</h3>
       <p class="about-preview">Partners are requested or assigned <strong>in person</strong> on a per-tournament basis.</p>
       <ul class="section-list">
-        <li>Have a preferred partner? Tell us—we’ll try to honor it based on availability.</li>
+        <li>Have a preferred partner? Tell us - we’ll try to honor it based on availability.</li>
         <li>New or flexible? We’ll pair you with someone compatible.</li>
-        <li>Not a fit? Partnerships can change between events—normal.</li>
+        <li>Not a fit? Partnerships can change between events - normal.</li>
       </ul>
     </section>
 
@@ -499,7 +499,7 @@
     <!-- Results placeholder -->
     <section class="glass-card reveal" id="results">
       <h3 class="about-header">Results & Highlights</h3>
-      <p class="about-preview">We’ll post monthly highlights here—breaks, speaker awards, and photos.</p>
+      <p class="about-preview">We’ll post monthly highlights here - breaks, speaker awards, and photos.</p>
     </section>
   </main>
 

--- a/why-pdu.html
+++ b/why-pdu.html
@@ -9,20 +9,20 @@
   <link href="https://fonts.googleapis.com/css2?family=DM+Serif+Display&family=Inter:wght@400;600&display=swap" rel="stylesheet">
 
   <!-- SEO -->
-  <meta name="description" content="Why join NYU PDU? Travel the APDA circuit, learn fast, and belong to a team that backs you—at $0 out of pocket." />
+  <meta name="description" content="Why join NYU PDU? Travel the APDA circuit, learn fast, and belong to a team that backs you - at $0 out of pocket." />
   <link rel="canonical" href="https://nyupdu.github.io/why-pdu.html" />
   <meta property="og:title" content="Why PDU | NYU Parliamentary Debate Union" />
-  <meta property="og:description" content="Train twice a week, compete most weekends, and find your voice—no experience needed." />
+  <meta property="og:description" content="Train twice a week, compete most weekends, and find your voice - no experience needed." />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://nyupdu.github.io/why-pdu.html" />
   <meta property="og:image" content="https://nyupdu.github.io/PDULOGO_Trans.png" />
 
   <!-- Page-local styles (scoped) -->
   <style>
-    /* ——— hero tweak ——— */
+    /*  -  -  -  hero tweak  -  -  -  */
     .hero-compact .page-subtitle{ max-width:60ch; margin: .5rem auto 0; }
 
-    /* ——— small stat badge ——— */
+    /*  -  -  -  small stat badge  -  -  -  */
     .stat-badge{
       display:inline-block;
       padding:.35rem .65rem; border-radius:999px;
@@ -32,7 +32,7 @@
       box-shadow:0 0 10px rgba(199,191,255,.22) inset;
     }
 
-    /* ——— compact cards ——— */
+    /*  -  -  -  compact cards  -  -  -  */
     .pillars{
       display:grid; gap:1rem; grid-template-columns:repeat(3,1fr);
       max-width:1100px; margin:1.25rem auto 0;
@@ -49,13 +49,13 @@
     .chips-row{ display:flex; flex-wrap:wrap; gap:.4rem; margin-top:.5rem; }
     .chips-row .chip{ font-size:.85rem; }
 
-    /* ——— two-up band ——— */
+    /*  -  -  -  two-up band  -  -  -  */
     .two-up{
       display:grid; gap:1.25rem; grid-template-columns:1fr 1fr;
       align-items:start;
     }
 
-    /* ——— simple vertical timeline ——— */
+    /*  -  -  -  simple vertical timeline  -  -  -  */
     .timeline{ position:relative; padding-left:1rem; }
     .timeline::before{
       content:""; position:absolute; left:.28rem; top:.1rem; bottom:.2rem;
@@ -70,7 +70,7 @@
     .tl-title{ font-weight:800; margin-bottom:.15rem; }
     .tl-note{ opacity:.92; }
 
-    /* ——— impact grid ——— */
+    /*  -  -  -  impact grid  -  -  -  */
     .impact{
       display:grid; gap:1rem; grid-template-columns:repeat(4,1fr);
     }
@@ -82,10 +82,10 @@
     .impact .card h4{ font-weight:800; margin-bottom:.25rem; }
     .impact .card p{ opacity:.95; }
 
-    /* ——— travel list (chips) ——— */
+    /*  -  -  -  travel list (chips)  -  -  -  */
     .travel-chips{ display:flex; flex-wrap:wrap; gap:.45rem; }
 
-    /* ——— details FAQ ——— */
+    /*  -  -  -  details FAQ  -  -  -  */
     .faq details{
       border:1px solid rgba(255,255,255,.22); border-radius:12px;
       background:rgba(255,255,255,.08); padding:.75rem 1rem; margin:.55rem 0;
@@ -95,7 +95,7 @@
     .faq summary:after{ content:'▾'; float:right; opacity:.9; }
     .faq details[open] summary:after{ content:'▴'; }
 
-    /* ——— contents drawer pill spacing on this page ——— */
+    /*  -  -  -  contents drawer pill spacing on this page  -  -  -  */
     .toc-pill{ top:calc(var(--nav-height) + 12px); }
 
     @media (max-width:1100px){
@@ -308,7 +308,7 @@
           <ul class="section-list">
             <li>Curiosity and a willingness to practice</li>
             <li>Two evenings a week (when you can make it)</li>
-            <li>A notebook or laptop if you like—nothing special required</li>
+            <li>A notebook or laptop if you like - nothing special required</li>
           </ul>
         </div>
       </div>
@@ -350,7 +350,7 @@
       <div class="impact">
         <div class="card">
           <h4>Clear thinking</h4>
-          <p>Claim, warrant, impact—make your case and make it stick.</p>
+          <p>Claim, warrant, impact - make your case and make it stick.</p>
         </div>
         <div class="card">
           <h4>Fast analysis</h4>
@@ -376,7 +376,7 @@
     <section class="glass-card reveal" id="selection">
       <h3 class="about-header">Selection & partners (transparent)</h3>
       <p class="about-preview">
-        We try to take everyone who’s ready. When spots are tight, recent participation helps us prioritize fairly. Partners are requested or assigned in person on a per-tournament basis—flexible and no hard commitments.
+        We try to take everyone who’s ready. When spots are tight, recent participation helps us prioritize fairly. Partners are requested or assigned in person on a per-tournament basis - flexible and no hard commitments.
       </p>
       <div class="cta-row">
         <a class="link-chip" href="about.html#meetings">Attendance guidelines →</a>
@@ -402,7 +402,7 @@
     <!-- Leadership & mentorship -->
     <section class="glass-card reveal" id="leadership">
       <h3 class="about-header">Leadership & mentorship</h3>
-      <p class="about-preview">Board-run, student-led. You’ll get feedback every step—from case ideas to round tapes.</p>
+      <p class="about-preview">Board-run, student-led. You’ll get feedback every step - from case ideas to round tapes.</p>
       <div class="cta-row">
         <a class="link-chip" href="leadership.html">Meet the board →</a>
         <a class="link-chip" href="contact.html">Contact us →</a>
@@ -422,7 +422,7 @@
       </details>
       <details>
         <summary>How do partners work?</summary>
-        <p class="about-preview" style="margin-top:.4rem;">Requested or assigned in person for each tournament—flexible and normal to switch.</p>
+        <p class="about-preview" style="margin-top:.4rem;">Requested or assigned in person for each tournament - flexible and normal to switch.</p>
       </details>
       <details>
         <summary>Is judging an option?</summary>
@@ -434,7 +434,7 @@
   <!-- CTA band -->
   <section class="cta-band">
     <h3>Ready to try a meeting?</h3>
-    <p>Open to all NYU students — no experience needed.</p>
+    <p>Open to all NYU students  -  no experience needed.</p>
     <div class="hero-ctas" style="margin-top:.5rem;">
       <a class="btn-primary" href="join.html">Join us</a>
       <a class="btn-secondary" href="calendar.html">See the calendar</a>


### PR DESCRIPTION
## Summary
- Reworded paragraphs across site pages to eliminate em-dash punctuation.
- Updated JS toast copy and form placeholders to use simple separators.

## Testing
- `npm test` *(fails: /usr/bin/npm: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b86a5a45a483229553a7130093df33