### PR TITLE
Add fall 2025 tentative tournaments

### DIFF
--- a/index.html
+++ b/index.html
@@ -159,6 +159,7 @@
     .featured-meta{ display:flex; gap:.5rem; flex-wrap:wrap; margin:.25rem 0 .6rem; }
     .featured-side{ text-align:right; }
     .featured-side .pill{ display:inline-block; }
+    .pill.tentative{ background:rgba(255,200,80,.12); border-color:rgba(255,200,80,.45); }
     @media (max-width: 960px){
       .featured-card{ grid-template-columns:1fr; text-align:left; }
       .featured-side{ text-align:left; }
@@ -381,19 +382,18 @@
     <section class="featured-wrap reveal" id="featured">
       <div class="featured-card">
         <div>
-          <h3 class="about-header" style="margin-bottom:.4rem;">Featured: Yale IV</h3>
+          <h3 class="about-header" style="margin-bottom:.4rem;">Featured: Bates</h3>
           <div class="featured-meta">
-            <span class="chip">Oct 4–5</span>
-            <span class="chip">New Haven, CT</span>
-            <span class="chip">5 prelims · Break to Octos</span>
+            <span class="chip">Sep 19–20</span>
+            <span class="chip">Lewiston, ME</span>
           </div>
-          <p class="about-preview" style="margin:.25rem 0 0;">Travel, reg, and lodging covered. Novices welcome.</p>
+          <p class="about-preview" style="margin:.25rem 0 0;">Travel, reg, and lodging covered. Details coming soon.</p>
           <div class="cta-row" style="margin-top:.6rem;">
             <a class="link-chip" href="tournaments.html">Event details →</a>
           </div>
         </div>
         <div class="featured-side">
-          <span class="pill">Status: Placeholder</span>
+          <span class="pill tentative">Tentative</span>
         </div>
       </div>
     </section>
@@ -403,21 +403,41 @@
       <div class="h-scroll">
         <article class="event-card">
           <div class="event-head">
-            <h4>Princeton Pro-Ams</h4>
-            <span class="pill">Oct 18–19</span>
+            <h4>Tufts</h4>
+            <span class="pill tentative">Tentative</span>
           </div>
-          <p class="event-meta">Princeton, NJ · Novice friendly</p>
-          <p class="event-note">Great for first-timers.</p>
+          <p class="event-meta">Sep 26–27 · Medford, MA</p>
+          <p class="event-note">Details coming soon.</p>
           <a class="link-chip" href="tournaments.html">Details →</a>
         </article>
 
         <article class="event-card">
           <div class="event-head">
-            <h4>Harvard Invitational</h4>
-            <span class="pill">Nov 1–2</span>
+            <h4>Boston University</h4>
+            <span class="pill tentative">Tentative</span>
           </div>
-          <p class="event-meta">Cambridge, MA · Large field</p>
-          <p class="event-note">High-energy weekend.</p>
+          <p class="event-meta">Oct 3–4 · Boston, MA</p>
+          <p class="event-note">Novice tournament.</p>
+          <a class="link-chip" href="tournaments.html">Details →</a>
+        </article>
+
+        <article class="event-card">
+          <div class="event-head">
+            <h4>Harvard</h4>
+            <span class="pill tentative">Tentative</span>
+          </div>
+          <p class="event-meta">Oct 10–11 · Cambridge, MA</p>
+          <p class="event-note">APDA Meeting.</p>
+          <a class="link-chip" href="tournaments.html">Details →</a>
+        </article>
+
+        <article class="event-card">
+          <div class="event-head">
+            <h4>Brown</h4>
+            <span class="pill tentative">Tentative</span>
+          </div>
+          <p class="event-meta">Oct 24–25 · Providence, RI</p>
+          <p class="event-note">Details coming soon.</p>
           <a class="link-chip" href="tournaments.html">Details →</a>
         </article>
       </div>

--- a/join.html
+++ b/join.html
@@ -398,7 +398,7 @@
           <ul>
             <li>Kickoff lessons begin</li>
             <li>First scrim night</li>
-              <li>Travel: TBD (placeholder)</li>
+              <li>Travel: Bates (tentative); Tufts (tentative)</li>
           </ul>
           <div class="cta-row"><a class="link-chip" href="calendar.html">Open calendar →</a></div>
         </div>
@@ -406,7 +406,7 @@
           <h4>October</h4>
           <ul>
             <li>Casebuilding workshop</li>
-              <li>Travel: TBD (placeholder)</li>
+              <li>Travel: Boston University Novice (tentative); Harvard (APDA Meeting, tentative); Brown (tentative)</li>
             <li>Novice spotlight night</li>
           </ul>
           <div class="cta-row"><a class="link-chip" href="calendar.html">Open calendar →</a></div>

--- a/members.html
+++ b/members.html
@@ -272,36 +272,22 @@
             </p>
 
             <div class="targets-grid overview">
-              <!-- TBD -->
-              <article class="target-card">
-                <span class="pill open">Sign-ups Open</span>
-                  <div class="chip-row"><span class="chip">Dates TBD</span><span class="chip">Region TBD</span></div>
-                  <h3>TBD</h3>
-                  <p class="about-preview" style="margin:.55rem 0 .65rem;">Details to be announced.</p>
-                <div class="cta-row">
-                  <a class="link-chip" href="tournaments.html">Details →</a>
-                  <a class="link-chip" href="calendar.html">Calendar →</a>
-                </div>
-              </article>
-
-              <!-- TBD -->
               <article class="target-card">
                 <span class="pill tentative">Tentative</span>
-                  <div class="chip-row"><span class="chip">Dates TBD</span><span class="chip">Region TBD</span></div>
-                  <h3>TBD</h3>
-                  <p class="about-preview" style="margin:.55rem 0 .65rem;">Details to be announced.</p>
+                <div class="chip-row"><span class="chip">Sep 19–20</span><span class="chip">Bates</span></div>
+                <h3>Bates</h3>
+                <p class="about-preview" style="margin:.55rem 0 .65rem;">Judges needed: TBD</p>
                 <div class="cta-row">
                   <a class="link-chip" href="tournaments.html">Details →</a>
                   <a class="link-chip" href="calendar.html">Calendar →</a>
                 </div>
               </article>
 
-              <!-- TBD -->
               <article class="target-card">
-                <span class="pill confirmed">Roster Confirmed</span>
-                  <div class="chip-row"><span class="chip">Dates TBD</span><span class="chip">Region TBD</span></div>
-                  <h3>TBD</h3>
-                  <p class="about-preview" style="margin:.55rem 0 .65rem;">Details to be announced.</p>
+                <span class="pill tentative">Tentative</span>
+                <div class="chip-row"><span class="chip">Sep 26–27</span><span class="chip">Tufts</span></div>
+                <h3>Tufts</h3>
+                <p class="about-preview" style="margin:.55rem 0 .65rem;">Judges needed: TBD</p>
                 <div class="cta-row">
                   <a class="link-chip" href="tournaments.html">Details →</a>
                   <a class="link-chip" href="calendar.html">Calendar →</a>
@@ -319,7 +305,7 @@
             <h4>October</h4>
             <ul>
               <li>Mon/Wed meetings · 7:00 PM</li>
-              <li>2–3 tournaments (sign-ups mid-month)</li>
+              <li>Travel: Boston University Novice · Harvard (APDA Meeting) · Brown</li>
             </ul>
             <div class="cta-row"><a class="link-chip" href="tournaments.html#october">See slate →</a></div>
           </div>

--- a/tournaments.html
+++ b/tournaments.html
@@ -242,20 +242,20 @@
       <div class="feature-card">
         <div class="feature-left">
           <div class="event-head">
-            <h3>TBD</h3>
-            <span class="pill open">Sign-ups open</span>
+            <h3>Bates</h3>
+            <span class="pill tentative">Tentative</span>
           </div>
           <div class="event-badges">
-            <span class="badge-need" data-judges-needed="3" title="Estimated judges needed">
+            <span class="badge-need" data-judges-needed="tbd" title="Estimated judges needed">
               <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
                 <path d="M7.5 7.5l4 4 5-5-4-4-5 5zm-1.4 1.4l-1.1 3.3 3.2-1.2 8-8-2.1-2.1-8 8zM3 21h18v-2H3v2z"/>
               </svg>
-              <span class="badge-text">Judges needed: <strong class="need-count">3</strong></span>
+              <span class="badge-text">Judges needed: <strong class="need-count">TBD</strong></span>
             </span>
           </div>
           <div class="meta">
-            <span class="chip">Location TBD</span>
-            <span class="chip">Dates TBD</span>
+            <span class="chip">Bates College</span>
+            <span class="chip">Sep 19–20</span>
           </div>
           <p class="muted">Details coming soon.</p>
           <ul class="section-list" style="margin-top:.6rem;">
@@ -264,7 +264,6 @@
             <li><strong>Funding:</strong> PDU covers travel, registration, lodging.</li>
           </ul>
           <div class="cta-row" style="margin-top:.75rem;">
-            <a class="link-chip" href="#" title="Placeholder link for interest form" target="_blank" rel="noopener">Interest form →</a>
             <a class="link-chip" href="calendar.html">Add/See on Calendar →</a>
             <a class="link-chip" href="https://drive.google.com/drive/folders/1SIot57czQp_hxY6Bx38I_SN4deVhbvDo?usp=drive_link" target="_blank" rel="noopener">TID (Drive) →</a>
           </div>
@@ -287,11 +286,11 @@
     <section class="glass-card reveal" id="upcoming">
       <h3 class="about-header">Upcoming Targets</h3>
       <div class="targets-grid" role="list">
-        <!-- Card 1: Sign-ups Open (shows Interest Form) -->
+        <!-- Bates -->
         <article class="target-card" role="listitem">
           <div class="event-head">
-              <h4>TBD</h4>
-            <span class="pill open">Sign-ups open</span>
+            <h4>Bates</h4>
+            <span class="pill tentative">Tentative</span>
           </div>
           <div class="event-badges">
             <span class="badge-need" data-judges-needed="tbd" title="Estimated judges needed">
@@ -301,23 +300,122 @@
               <span class="badge-text">Judges needed: <strong class="need-count">TBD</strong></span>
             </span>
           </div>
-            <div class="meta">
-              <span class="chip">Dates TBD</span>
-            </div>
-            <p class="about-preview" style="margin:.25rem 0 .4rem;">Details to be announced.</p>
+          <div class="meta">
+            <span class="chip">Bates College</span>
+            <span class="chip">Sep 19–20</span>
+          </div>
+          <p class="about-preview" style="margin:.25rem 0 .4rem;">Details to be announced.</p>
           <div class="cta-row">
-            <a class="link-chip" href="#" title="Placeholder link for interest form" target="_blank" rel="noopener">Interest form →</a>
             <a class="link-chip" href="calendar.html">Calendar →</a>
             <a class="link-chip" href="https://drive.google.com/drive/folders/1SIot57czQp_hxY6Bx38I_SN4deVhbvDo?usp=drive_link" target="_blank" rel="noopener">TID →</a>
           </div>
-          <p class="note">Sign up to debate <em>or</em> judge  -  choose your role in the form.</p>
         </article>
 
-        <!-- Card 2: Tentative -->
+        <!-- Tufts -->
         <article class="target-card" role="listitem">
           <div class="event-head">
-              <h4>TBD</h4>
+            <h4>Tufts</h4>
             <span class="pill tentative">Tentative</span>
+          </div>
+          <div class="event-badges">
+            <span class="badge-need" data-judges-needed="tbd" title="Estimated judges needed">
+              <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M7.5 7.5l4 4 5-5-4-4-5 5zm-1.4 1.4l-1.1 3.3 3.2-1.2 8-8-2.1-2.1-8 8zM3 21h18v-2H3v2z"/>
+              </svg>
+              <span class="badge-text">Judges needed: <strong class="need-count">TBD</strong></span>
+            </span>
+          </div>
+          <div class="meta">
+            <span class="chip">Tufts University</span>
+            <span class="chip">Sep 26–27</span>
+          </div>
+          <p class="about-preview" style="margin:.25rem 0 .4rem;">Details to be announced.</p>
+          <div class="cta-row">
+            <a class="link-chip" href="calendar.html">Calendar →</a>
+            <a class="link-chip" href="https://drive.google.com/drive/folders/1SIot57czQp_hxY6Bx38I_SN4deVhbvDo?usp=drive_link" target="_blank" rel="noopener">TID →</a>
+          </div>
+        </article>
+
+        <!-- Boston University (Novice Tournament) -->
+        <article class="target-card" role="listitem">
+          <div class="event-head">
+            <h4>Boston University</h4>
+            <span class="pill tentative">Tentative</span>
+          </div>
+          <div class="event-badges">
+            <span class="badge-need" data-judges-needed="tbd" title="Estimated judges needed">
+              <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M7.5 7.5l4 4 5-5-4-4-5 5zm-1.4 1.4l-1.1 3.3 3.2-1.2 8-8-2.1-2.1-8 8zM3 21h18v-2H3v2z"/>
+              </svg>
+              <span class="badge-text">Judges needed: <strong class="need-count">TBD</strong></span>
+            </span>
+          </div>
+          <div class="meta">
+            <span class="chip">Novice Tournament</span>
+            <span class="chip">Oct 3–4</span>
+          </div>
+          <p class="about-preview" style="margin:.25rem 0 .4rem;">Novice tournament.</p>
+          <div class="cta-row">
+            <a class="link-chip" href="calendar.html">Calendar →</a>
+            <a class="link-chip" href="https://drive.google.com/drive/folders/1SIot57czQp_hxY6Bx38I_SN4deVhbvDo?usp=drive_link" target="_blank" rel="noopener">TID →</a>
+          </div>
+        </article>
+
+        <!-- Harvard (APDA Meeting) -->
+        <article class="target-card" role="listitem">
+          <div class="event-head">
+            <h4>Harvard</h4>
+            <span class="pill tentative">Tentative</span>
+          </div>
+          <div class="event-badges">
+            <span class="badge-need" data-judges-needed="tbd" title="Estimated judges needed">
+              <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M7.5 7.5l4 4 5-5-4-4-5 5zm-1.4 1.4l-1.1 3.3 3.2-1.2 8-8-2.1-2.1-8 8zM3 21h18v-2H3v2z"/>
+              </svg>
+              <span class="badge-text">Judges needed: <strong class="need-count">TBD</strong></span>
+            </span>
+          </div>
+          <div class="meta">
+            <span class="chip">APDA Meeting</span>
+            <span class="chip">Oct 10–11</span>
+          </div>
+          <p class="about-preview" style="margin:.25rem 0 .4rem;">Includes APDA meeting.</p>
+          <div class="cta-row">
+            <a class="link-chip" href="calendar.html">Calendar →</a>
+            <a class="link-chip" href="https://drive.google.com/drive/folders/1SIot57czQp_hxY6Bx38I_SN4deVhbvDo?usp=drive_link" target="_blank" rel="noopener">TID →</a>
+          </div>
+        </article>
+
+        <!-- Brown -->
+        <article class="target-card" role="listitem">
+          <div class="event-head">
+            <h4>Brown</h4>
+            <span class="pill tentative">Tentative</span>
+          </div>
+          <div class="event-badges">
+            <span class="badge-need" data-judges-needed="tbd" title="Estimated judges needed">
+              <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M7.5 7.5l4 4 5-5-4-4-5 5zm-1.4 1.4l-1.1 3.3 3.2-1.2 8-8-2.1-2.1-8 8zM3 21h18v-2H3v2z"/>
+              </svg>
+              <span class="badge-text">Judges needed: <strong class="need-count">TBD</strong></span>
+            </span>
+          </div>
+          <div class="meta">
+            <span class="chip">Brown University</span>
+            <span class="chip">Oct 24–25</span>
+          </div>
+          <p class="about-preview" style="margin:.25rem 0 .4rem;">Details to be announced.</p>
+          <div class="cta-row">
+            <a class="link-chip" href="calendar.html">Calendar →</a>
+            <a class="link-chip" href="https://drive.google.com/drive/folders/1SIot57czQp_hxY6Bx38I_SN4deVhbvDo?usp=drive_link" target="_blank" rel="noopener">TID →</a>
+          </div>
+        </article>
+
+        <!-- Sample: Sign-ups Open -->
+        <article class="target-card" role="listitem">
+          <div class="event-head">
+            <h4>TBD</h4>
+            <span class="pill open">Sign-ups open</span>
           </div>
           <div class="event-badges">
             <span class="badge-need" data-judges-needed="2" title="Estimated judges needed">
@@ -327,20 +425,22 @@
               <span class="badge-text">Judges needed: <strong class="need-count">2</strong></span>
             </span>
           </div>
-            <div class="meta">
-              <span class="chip">Dates TBD</span>
-            </div>
-            <p class="about-preview" style="margin:.25rem 0 .4rem;">Details to be announced.</p>
+          <div class="meta">
+            <span class="chip">Dates TBD</span>
+          </div>
+          <p class="about-preview" style="margin:.25rem 0 .4rem;">Details to be announced.</p>
           <div class="cta-row">
+            <a class="link-chip" href="#" title="Placeholder link for interest form" target="_blank" rel="noopener">Interest form →</a>
             <a class="link-chip" href="calendar.html">Calendar →</a>
             <a class="link-chip" href="https://drive.google.com/drive/folders/1SIot57czQp_hxY6Bx38I_SN4deVhbvDo?usp=drive_link" target="_blank" rel="noopener">TID →</a>
           </div>
+          <p class="note">Sign up to debate <em>or</em> judge  -  choose your role in the form.</p>
         </article>
 
-        <!-- Card 3: Confirmed -->
+        <!-- Sample: Roster Confirmed -->
         <article class="target-card" role="listitem">
           <div class="event-head">
-              <h4>TBD</h4>
+            <h4>TBD</h4>
             <span class="pill confirmed">Roster Confirmed</span>
           </div>
           <div class="event-badges">
@@ -351,34 +451,10 @@
               <span class="badge-text">Judges needed: <strong class="need-count">0</strong></span>
             </span>
           </div>
-            <div class="meta">
-              <span class="chip">Dates TBD</span>
-            </div>
-            <p class="about-preview" style="margin:.25rem 0 .4rem;">Details to be announced.</p>
-          <div class="cta-row">
-            <a class="link-chip" href="calendar.html">Calendar →</a>
-            <a class="link-chip" href="https://drive.google.com/drive/folders/1SIot57czQp_hxY6Bx38I_SN4deVhbvDo?usp=drive_link" target="_blank" rel="noopener">TID →</a>
+          <div class="meta">
+            <span class="chip">Dates TBD</span>
           </div>
-        </article>
-
-        <!-- Card 4: Tentative -->
-        <article class="target-card" role="listitem">
-          <div class="event-head">
-              <h4>TBD</h4>
-            <span class="pill tentative">Tentative</span>
-          </div>
-          <div class="event-badges">
-            <span class="badge-need" data-judges-needed="1" title="Estimated judges needed">
-              <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
-                <path d="M7.5 7.5l4 4 5-5-4-4-5 5zm-1.4 1.4l-1.1 3.3 3.2-1.2 8-8-2.1-2.1-8 8zM3 21h18v-2H3v2z"/>
-              </svg>
-              <span class="badge-text">Judges needed: <strong class="need-count">1</strong></span>
-            </span>
-          </div>
-            <div class="meta">
-              <span class="chip">Dates TBD</span>
-            </div>
-            <p class="about-preview" style="margin:.25rem 0 .4rem;">Details to be announced.</p>
+          <p class="about-preview" style="margin:.25rem 0 .4rem;">Details to be announced.</p>
           <div class="cta-row">
             <a class="link-chip" href="calendar.html">Calendar →</a>
             <a class="link-chip" href="https://drive.google.com/drive/folders/1SIot57czQp_hxY6Bx38I_SN4deVhbvDo?usp=drive_link" target="_blank" rel="noopener">TID →</a>


### PR DESCRIPTION
## Summary
- Add fall 2025 tournaments (Bates, Tufts, Boston University Novice, Harvard APDA Meeting, Brown) with tentative status and TBD judge counts
- Refresh homepage and member resources with new tournament dates
- Keep sample cards demonstrating sign-ups open and roster confirmed states

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bb821278c08322bae8f2b67ff997c6