### PR TITLE
Add Instagram link in footer

### DIFF
--- a/about.html
+++ b/about.html
@@ -284,6 +284,7 @@
 
   <footer class="glass-footer">
     <p>© 2025 NYU Parliamentary Debate Union. All rights reserved. Site design by <a href="https://www.linkedin.com/in/marcelcato/" target="_blank" rel="noopener">Marcel Cato</a>.</p>
+    <p class="social"><a href="https://www.instagram.com/nyudebate/" target="_blank" rel="noopener"><img src="instagramlogo.png" alt="Instagram logo">@nyudebate</a></p>
     <p class="disclaimer">NYU PDU is a student-run club, approved by but not affiliated with New York University in an institutional capacity.</p>
   </footer>
 

--- a/advanced.html
+++ b/advanced.html
@@ -717,6 +717,7 @@
        ========================================= -->
   <footer class="glass-footer">
     <p>© 2025 NYU Parliamentary Debate Union. All rights reserved.</p>
+    <p class="social"><a href="https://www.instagram.com/nyudebate/" target="_blank" rel="noopener"><img src="instagramlogo.png" alt="Instagram logo">@nyudebate</a></p>
   </footer>
 
   <!-- =========================================

--- a/beginner.html
+++ b/beginner.html
@@ -644,6 +644,7 @@
 
   <footer class="glass-footer">
     <p>© 2025 NYU Parliamentary Debate Union. All rights reserved. Site design by <a href="https://www.linkedin.com/in/marcelcato/" target="_blank" rel="noopener">Marcel Cato</a>.</p>
+    <p class="social"><a href="https://www.instagram.com/nyudebate/" target="_blank" rel="noopener"><img src="instagramlogo.png" alt="Instagram logo">@nyudebate</a></p>
     <p class="disclaimer">NYU PDU is a student-run club, approved by but not affiliated with New York University in an institutional capacity.</p>
   </footer>
 

--- a/calendar.html
+++ b/calendar.html
@@ -166,6 +166,7 @@
 
   <footer class="glass-footer">
     <p>© 2025 NYU Parliamentary Debate Union. All rights reserved. Site design by <a href="https://www.linkedin.com/in/marcelcato/" target="_blank" rel="noopener">Marcel Cato</a>.</p>
+    <p class="social"><a href="https://www.instagram.com/nyudebate/" target="_blank" rel="noopener"><img src="instagramlogo.png" alt="Instagram logo">@nyudebate</a></p>
     <p class="disclaimer">NYU PDU is a student-run club, approved by but not affiliated with New York University in an institutional capacity.</p>
   </footer>
 

--- a/contact.html
+++ b/contact.html
@@ -360,6 +360,7 @@
   <!-- ===== Footer ===== -->
   <footer class="glass-footer">
     <p>© 2025 NYU Parliamentary Debate Union. All rights reserved. Site design by <a href="https://www.linkedin.com/in/marcelcato/" target="_blank" rel="noopener">Marcel Cato</a>.</p>
+    <p class="social"><a href="https://www.instagram.com/nyudebate/" target="_blank" rel="noopener"><img src="instagramlogo.png" alt="Instagram logo">@nyudebate</a></p>
     <p class="disclaimer">NYU PDU is a student-run club, approved by but not affiliated with New York University in an institutional capacity.</p>
   </footer>
 

--- a/equity.html
+++ b/equity.html
@@ -321,6 +321,7 @@
 
   <footer class="glass-footer">
     <p>© 2025 NYU Parliamentary Debate Union. All rights reserved. Site design by <a href="https://www.linkedin.com/in/marcelcato/" target="_blank" rel="noopener">Marcel Cato</a>.</p>
+    <p class="social"><a href="https://www.instagram.com/nyudebate/" target="_blank" rel="noopener"><img src="instagramlogo.png" alt="Instagram logo">@nyudebate</a></p>
     <p class="disclaimer">NYU PDU is a student-run club, approved by but not affiliated with New York University in an institutional capacity.</p>
   </footer>
 

--- a/index.html
+++ b/index.html
@@ -500,6 +500,7 @@
 
   <footer class="glass-footer">
     <p>© 2025 NYU Parliamentary Debate Union. All rights reserved. Site design by <a href="https://www.linkedin.com/in/marcelcato/" target="_blank" rel="noopener">Marcel Cato</a>.</p>
+    <p class="social"><a href="https://www.instagram.com/nyudebate/" target="_blank" rel="noopener"><img src="instagramlogo.png" alt="Instagram logo">@nyudebate</a></p>
     <p class="disclaimer">NYU PDU is a student-run club, approved by but not affiliated with New York University in an institutional capacity.</p>
   </footer>
 

--- a/join.html
+++ b/join.html
@@ -482,6 +482,7 @@
 
   <footer class="glass-footer">
     <p>© 2025 NYU Parliamentary Debate Union. All rights reserved. Site design by <a href="https://www.linkedin.com/in/marcelcato/" target="_blank" rel="noopener">Marcel Cato</a>.</p>
+    <p class="social"><a href="https://www.instagram.com/nyudebate/" target="_blank" rel="noopener"><img src="instagramlogo.png" alt="Instagram logo">@nyudebate</a></p>
     <p class="disclaimer">NYU PDU is a student-run club, approved by but not affiliated with New York University in an institutional capacity.</p>
   </footer>
 

--- a/judging.html
+++ b/judging.html
@@ -643,6 +643,7 @@
   <!-- ============== FOOTER ============== -->
   <footer class="glass-footer">
     <p>© 2025 NYU Parliamentary Debate Union. All rights reserved. Site design by <a href="https://www.linkedin.com/in/marcelcato/" target="_blank" rel="noopener">Marcel Cato</a>.</p>
+    <p class="social"><a href="https://www.instagram.com/nyudebate/" target="_blank" rel="noopener"><img src="instagramlogo.png" alt="Instagram logo">@nyudebate</a></p>
     <p class="disclaimer">NYU PDU is a student-run club, approved by but not affiliated with New York University in an institutional capacity.</p>
   </footer>
 

--- a/leadership.html
+++ b/leadership.html
@@ -463,6 +463,7 @@
   <!-- Footer -->
   <footer class="glass-footer">
     <p>© 2025 NYU Parliamentary Debate Union. All rights reserved.</p>
+    <p class="social"><a href="https://www.instagram.com/nyudebate/" target="_blank" rel="noopener"><img src="instagramlogo.png" alt="Instagram logo">@nyudebate</a></p>
     <p class="disclaimer">NYU PDU is a student-run club, approved by but not affiliated with New York University in an institutional capacity.</p>
   </footer>
 

--- a/members.html
+++ b/members.html
@@ -448,6 +448,7 @@
   <!-- ===== FOOTER ===== -->
   <footer class="glass-footer">
     <p>© 2025 NYU Parliamentary Debate Union. All rights reserved.</p>
+    <p class="social"><a href="https://www.instagram.com/nyudebate/" target="_blank" rel="noopener"><img src="instagramlogo.png" alt="Instagram logo">@nyudebate</a></p>
   </footer>
 
   <!-- Back to top -->

--- a/practicetools.html
+++ b/practicetools.html
@@ -679,6 +679,7 @@ Reason #2  -  warrants → impact"></textarea>
   <!-- ====================== FOOTER ====================== -->
   <footer class="glass-footer">
     <p>© 2025 NYU Parliamentary Debate Union. All rights reserved. Site design by <a href="https://www.linkedin.com/in/marcelcato/" target="_blank" rel="noopener">Marcel Cato</a>.</p>
+    <p class="social"><a href="https://www.instagram.com/nyudebate/" target="_blank" rel="noopener"><img src="instagramlogo.png" alt="Instagram logo">@nyudebate</a></p>
     <p class="disclaimer">NYU PDU is a student-run club, approved by but not affiliated with New York University in an institutional capacity.</p>
   </footer>
 

--- a/resources.html
+++ b/resources.html
@@ -553,6 +553,7 @@
   <!-- ====================== FOOTER ====================== -->
   <footer class="glass-footer">
     <p>© 2025 NYU Parliamentary Debate Union. All rights reserved. Site design by <a href="https://www.linkedin.com/in/marcelcato/" target="_blank" rel="noopener">Marcel Cato</a>.</p>
+    <p class="social"><a href="https://www.instagram.com/nyudebate/" target="_blank" rel="noopener"><img src="instagramlogo.png" alt="Instagram logo">@nyudebate</a></p>
     <p class="disclaimer">NYU PDU is a student-run club, approved by but not affiliated with New York University in an institutional capacity.</p>
   </footer>
 

--- a/style.css
+++ b/style.css
@@ -375,6 +375,21 @@ section[id] .about-header, section[id] h3, section[id] h4{ scroll-margin-top:96p
   margin-top:.3rem;
 }
 
+.glass-footer .social{
+  margin-top:.3rem;
+}
+.glass-footer .social a{
+  display:inline-flex;
+  align-items:center;
+  gap:.3rem;
+  color:inherit;
+  font-size:.8rem;
+  text-decoration:none;
+}
+.glass-footer .social img{
+  height:20px;
+}
+
 /* ================= Contents Drawer (About)  -  locked in ================= */
 .toc-drawer{
   position:fixed; top:calc(var(--nav-height) + 10px); left:0; bottom:30px; width:280px;

--- a/tournaments.html
+++ b/tournaments.html
@@ -581,6 +581,7 @@
 
   <footer class="glass-footer">
     <p>© 2025 NYU Parliamentary Debate Union. All rights reserved. Site design by <a href="https://www.linkedin.com/in/marcelcato/" target="_blank" rel="noopener">Marcel Cato</a>.</p>
+    <p class="social"><a href="https://www.instagram.com/nyudebate/" target="_blank" rel="noopener"><img src="instagramlogo.png" alt="Instagram logo">@nyudebate</a></p>
     <p class="disclaimer">NYU PDU is a student-run club, approved by but not affiliated with New York University in an institutional capacity.</p>
   </footer>
 

--- a/why-pdu.html
+++ b/why-pdu.html
@@ -443,6 +443,7 @@
 
   <footer class="glass-footer">
     <p>© 2025 NYU Parliamentary Debate Union. All rights reserved.</p>
+    <p class="social"><a href="https://www.instagram.com/nyudebate/" target="_blank" rel="noopener"><img src="instagramlogo.png" alt="Instagram logo">@nyudebate</a></p>
   </footer>
 
   <!-- Back to top -->


### PR DESCRIPTION
## Summary
- Add Instagram logo and @nyudebate handle to footer of every page
- Style footer social link for consistent display

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68be088510e88322ae81e1bc6766601e