### PR TITLE
feat: add notable achievements sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -470,6 +470,26 @@
       </div>
     </section>
 
+    <!-- Notable Achievements -->
+    <section class="glass-card reveal" id="home-achievements">
+      <h3 class="about-header">Notable Achievements</h3>
+      <h4>2024–25</h4>
+      <ul>
+        <li>UVA Tournament, 5th best varsity speaker</li>
+        <li>American University Tournament, 6th best varsity speaker</li>
+        <li>Columbia University Tournament, 10th best varsity team</li>
+      </ul>
+      <h4>2023–24</h4>
+      <ul>
+        <li>2nd best team of the year, Ailin Jia and Aadhavaarasan Raviarasan</li>
+        <li>8th best club of the year</li>
+        <li>2nd best speaker of the year, Aadhavaarasan Raviarasan</li>
+      </ul>
+      <div class="cta-row">
+        <a class="link-chip" href="tournaments.html#achievements">More details →</a>
+      </div>
+    </section>
+
     <!-- Recent highlight (photo-first) -->
     <section class="glass-card highlight-card reveal">
       <div class="highlight-media">

--- a/tournaments.html
+++ b/tournaments.html
@@ -231,6 +231,7 @@
       <a href="#logistics">Logistics & Costs</a>
       <a href="#partners">Partners & Roles</a>
       <a href="#equity">Equity & Safety</a>
+      <a href="#achievements">Notable Achievements</a>
       <a href="#results">Results & Highlights</a>
     </nav>
   </aside>
@@ -570,6 +571,23 @@
       <div class="cta-row">
         <a class="link-chip" href="equity.html">Read PDU Equity Policy →</a>
       </div>
+    </section>
+
+    <!-- Notable Achievements -->
+    <section class="glass-card reveal" id="achievements">
+      <h3 class="about-header">Notable Achievements</h3>
+      <h4>2024–25</h4>
+      <ul>
+        <li>UVA Tournament, 5th best varsity speaker</li>
+        <li>American University Tournament, 6th best varsity speaker</li>
+        <li>Columbia University Tournament, 10th best varsity team</li>
+      </ul>
+      <h4>2023–24</h4>
+      <ul>
+        <li>2nd best team of the year, Ailin Jia and Aadhavaarasan Raviarasan</li>
+        <li>8th best club of the year</li>
+        <li>2nd best speaker of the year, Aadhavaarasan Raviarasan</li>
+      </ul>
     </section>
 
     <!-- Results placeholder -->


### PR DESCRIPTION
## Summary
- highlight 2024–25 and 2023–24 milestones on tournaments page in dedicated Notable Achievements card
- feature the same achievements on the home page with a link to tournament details

## Testing
- `npm test` *(fails: Could not read package.json: ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68bf5fcfecf0832290f44ebfb3bb4c70