### PR TITLE
Revamp achievements sections with cards and badges

### DIFF
--- a/index.html
+++ b/index.html
@@ -378,6 +378,26 @@
       </article>
     </section>
 
+    <!-- Notable Achievements -->
+    <section class="glass-card reveal" id="home-achievements">
+      <h3 class="about-header">Notable Achievements</h3>
+      <h4 class="year-badge">2024–25</h4>
+      <div class="achievement-grid">
+        <div class="achievement-card"><span class="achievement-icon">🏆</span>UVA Tournament, 5th best varsity speaker</div>
+        <div class="achievement-card"><span class="achievement-icon">🏆</span>American University Tournament, 6th best varsity speaker</div>
+        <div class="achievement-card"><span class="achievement-icon">🏆</span>Columbia University Tournament, 10th best varsity team</div>
+      </div>
+      <h4 class="year-badge">2023–24</h4>
+      <div class="achievement-grid">
+        <div class="achievement-card"><span class="achievement-icon">🏆</span>2nd best team of the year, Ailin Jia and Aadhavaarasan Raviarasan</div>
+        <div class="achievement-card"><span class="achievement-icon">🏆</span>8th best club of the year</div>
+        <div class="achievement-card"><span class="achievement-icon">🏆</span>2nd best speaker of the year, Aadhavaarasan Raviarasan</div>
+      </div>
+      <div class="cta-row">
+        <a class="link-chip" href="tournaments.html#achievements">More details →</a>
+      </div>
+    </section>
+
     <!-- Featured tournament -->
     <section class="featured-wrap reveal" id="featured">
       <div class="featured-card">
@@ -467,26 +487,6 @@
       </div>
       <div class="cta-row">
         <a class="link-chip" href="why-pdu.html">Read the full Why PDU →</a>
-      </div>
-    </section>
-
-    <!-- Notable Achievements -->
-    <section class="glass-card reveal" id="home-achievements">
-      <h3 class="about-header">Notable Achievements</h3>
-      <h4>2024–25</h4>
-      <ul>
-        <li>UVA Tournament, 5th best varsity speaker</li>
-        <li>American University Tournament, 6th best varsity speaker</li>
-        <li>Columbia University Tournament, 10th best varsity team</li>
-      </ul>
-      <h4>2023–24</h4>
-      <ul>
-        <li>2nd best team of the year, Ailin Jia and Aadhavaarasan Raviarasan</li>
-        <li>8th best club of the year</li>
-        <li>2nd best speaker of the year, Aadhavaarasan Raviarasan</li>
-      </ul>
-      <div class="cta-row">
-        <a class="link-chip" href="tournaments.html#achievements">More details →</a>
       </div>
     </section>
 

--- a/style.css
+++ b/style.css
@@ -449,3 +449,28 @@ section[id] .about-header, section[id] h3, section[id] h4{ scroll-margin-top:96p
 /* Highlight Join Us link */
 .join-link{ color:#ffd700; text-shadow:0 0 8px rgba(255,215,0,.8); }
 .drawer-list .join-link{ color:#ffd700; text-shadow:0 0 8px rgba(255,215,0,.8); }
+
+/* ================= Notable Achievements ================= */
+.achievement-grid{
+  display:grid;
+  grid-template-columns:repeat(auto-fit,minmax(260px,1fr));
+  gap:.75rem;
+  margin:.5rem 0 1.2rem;
+}
+.achievement-card{
+  display:flex; align-items:flex-start; gap:.5rem;
+  background:rgba(255,255,255,.10); border:1px solid rgba(255,255,255,.25);
+  border-radius:12px; padding:.65rem .75rem; backdrop-filter:blur(8px);
+  transition:background .25s ease;
+}
+.achievement-card:hover{ background:rgba(255,255,255,.18); }
+.achievement-icon{ font-size:1.2rem; line-height:1; }
+.year-badge{
+  display:inline-block;
+  margin:.8rem 0 .4rem;
+  padding:.2rem .6rem;
+  border-radius:8px;
+  background:rgba(124,58,237,.25);
+  border:1px solid rgba(255,255,255,.25);
+  font-weight:700;
+}

--- a/tournaments.html
+++ b/tournaments.html
@@ -224,6 +224,7 @@
     <nav class="toc-list">
       <a href="#featured" class="active">Featured Tournament</a>
       <a href="#upcoming">Upcoming Targets</a>
+      <a href="#achievements">Notable Achievements</a>
       <a href="#judging">Judging</a>
       <a href="#primer">How APDA Works</a>
       <a href="#eligibility">Eligibility & Selection</a>
@@ -231,7 +232,6 @@
       <a href="#logistics">Logistics & Costs</a>
       <a href="#partners">Partners & Roles</a>
       <a href="#equity">Equity & Safety</a>
-      <a href="#achievements">Notable Achievements</a>
       <a href="#results">Results & Highlights</a>
     </nav>
   </aside>
@@ -464,6 +464,23 @@
       </div>
     </section>
 
+    <!-- Notable Achievements -->
+    <section class="glass-card reveal" id="achievements">
+      <h3 class="about-header">Notable Achievements</h3>
+      <h4 class="year-badge">2024–25</h4>
+      <div class="achievement-grid">
+        <div class="achievement-card"><span class="achievement-icon">🏆</span>UVA Tournament, 5th best varsity speaker</div>
+        <div class="achievement-card"><span class="achievement-icon">🏆</span>American University Tournament, 6th best varsity speaker</div>
+        <div class="achievement-card"><span class="achievement-icon">🏆</span>Columbia University Tournament, 10th best varsity team</div>
+      </div>
+      <h4 class="year-badge">2023–24</h4>
+      <div class="achievement-grid">
+        <div class="achievement-card"><span class="achievement-icon">🏆</span>2nd best team of the year, Ailin Jia and Aadhavaarasan Raviarasan</div>
+        <div class="achievement-card"><span class="achievement-icon">🏆</span>8th best club of the year</div>
+        <div class="achievement-card"><span class="achievement-icon">🏆</span>2nd best speaker of the year, Aadhavaarasan Raviarasan</div>
+      </div>
+    </section>
+
     <!-- Judging info -->
     <section class="glass-card reveal" id="judging">
       <h3 class="about-header">Judging</h3>
@@ -571,23 +588,6 @@
       <div class="cta-row">
         <a class="link-chip" href="equity.html">Read PDU Equity Policy →</a>
       </div>
-    </section>
-
-    <!-- Notable Achievements -->
-    <section class="glass-card reveal" id="achievements">
-      <h3 class="about-header">Notable Achievements</h3>
-      <h4>2024–25</h4>
-      <ul>
-        <li>UVA Tournament, 5th best varsity speaker</li>
-        <li>American University Tournament, 6th best varsity speaker</li>
-        <li>Columbia University Tournament, 10th best varsity team</li>
-      </ul>
-      <h4>2023–24</h4>
-      <ul>
-        <li>2nd best team of the year, Ailin Jia and Aadhavaarasan Raviarasan</li>
-        <li>8th best club of the year</li>
-        <li>2nd best speaker of the year, Aadhavaarasan Raviarasan</li>
-      </ul>
     </section>
 
     <!-- Results placeholder -->


### PR DESCRIPTION
## Summary
- Replace bullet achievements with grid cards and trophy icons
- Highlight years with badges and move achievements earlier on home and tournaments pages
- Style achievements grid and badges in CSS

## Testing
- `npx -y htmlhint index.html tournaments.html`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bf6d0b4a0883228eeb6a2ebca190f7