### PR TITLE
feat: add header for upcoming tournaments

### DIFF
--- a/index.html
+++ b/index.html
@@ -420,6 +420,7 @@
 
     <!-- Remaining tournament strip -->
     <section class="section-wrap reveal" aria-label="More upcoming tournaments">
+      <h3 class="about-header">Upcoming Tournaments</h3>
       <div class="h-scroll">
         <article class="event-card">
           <div class="event-head">


### PR DESCRIPTION
## Summary
- add "Upcoming Tournaments" header above upcoming tournament carousel

## Testing
- `npx --yes htmlhint index.html`


------
https://chatgpt.com/codex/tasks/task_e_68bf71dcc69c8322b74b243e7f7edb61