### PR TITLE
Add Instagram and Discord links to members dashboard

### DIFF
--- a/members.html
+++ b/members.html
@@ -438,6 +438,8 @@
               <a class="link-chip" href="equity.html">Equity Policy →</a>
               <a class="link-chip" href="contact.html">Feedback →</a>
               <a class="link-chip" href="calendar.html#subscribe">Subscribe to the calendar →</a>
+              <a class="link-chip" href="https://www.instagram.com/nyudebate/" target="_blank" rel="noopener">Instagram →</a>
+              <a class="link-chip" href="https://tinyurl.com/pdunyu" target="_blank" rel="noopener">Discord →</a>
             </div>
           </div>
         </div>
@@ -446,10 +448,11 @@
   </main>
 
   <!-- ===== FOOTER ===== -->
-  <footer class="glass-footer">
-    <p>© 2025 NYU Parliamentary Debate Union. All rights reserved.</p>
-    <p class="social"><a href="https://www.instagram.com/nyudebate/" target="_blank" rel="noopener"><img src="instagramlogo.png" alt="Instagram logo">@nyudebate</a></p>
-  </footer>
+    <footer class="glass-footer">
+      <p>© 2025 NYU Parliamentary Debate Union. All rights reserved.</p>
+      <p class="social"><a href="https://www.instagram.com/nyudebate/" target="_blank" rel="noopener"><img src="instagramlogo.png" alt="Instagram logo">@nyudebate</a></p>
+      <p class="social"><a href="https://tinyurl.com/pdunyu" target="_blank" rel="noopener">Discord</a></p>
+    </footer>
 
   <!-- Back to top -->
   <a href="#top" id="float-button" title="Back to top">


### PR DESCRIPTION
## Summary
- Add Instagram and Discord link chips to the members dashboard quick links section
- Include a Discord link in the page footer

## Testing
- `html5validator members.html` *(reports existing validation errors about CSS property `backdrop-filter`, iframe attributes `width`, `frameborder`, and `scrolling`)*

------
https://chatgpt.com/codex/tasks/task_e_68bf289fc8048322a9822bdf99f60488