### PR TITLE
Add Club Fest Fall 2025 highlight to homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -494,11 +494,11 @@
     <!-- Recent highlight (photo-first) -->
     <section class="glass-card highlight-card reveal">
       <div class="highlight-media">
-        <img src="placeholder.jpg" alt="PDU at recent tournament (placeholder)" loading="lazy">
+        <img src="ClubfestFall2025-highlight.jpg" alt="NYU PDU at Club Fest Fall 2025" loading="lazy">
       </div>
       <div class="highlight-body">
         <h3 class="about-header">Recent Highlights</h3>
-        <p>Stay tuned—highlights will appear here soon.</p>
+        <p>Thrilled to meet so many new faces at Club Fest Fall 2025! Thanks and welcome to everyone who expressed interest in signing up, and here's to a good semester of debate at PDU!</p>
       </div>
     </section>
 


### PR DESCRIPTION
## Summary
- showcase Club Fest Fall 2025 with new highlight photo on the homepage
- share welcoming message for newcomers in recent highlights section

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c0a8dc9494832291cd0c1670d27186