### PR TITLE
Update announcement board for fall welcome

### DIFF
--- a/members.html
+++ b/members.html
@@ -377,48 +377,18 @@
             <p class="about-preview">Latest updates from the board. Action items at a glance.</p>
 
             <div class="announce-grid" style="margin-top:.7rem;">
-              <!-- Wide announcement -->
               <div class="announce wide">
                 <article class="target-card">
-                  <span class="pill confirmed">Sep 2</span>
-                  <h4>Kickoff Meeting & Pizza</h4>
-                  <p class="about-preview">Welcome back! We’ll cover fall goals, travel norms, and how sign-ups work.</p>
+                  <span class="pill confirmed">Sep 10</span>
+                  <h4>Fall Welcome</h4>
+                  <p class="about-preview">Welcome back to PDU. Join us, Sep 10th at 7PM for our Kick-off Meeting!</p>
+                  <p class="about-preview">We're thrilled to have seen so many new faces at Club Fest. Now, we're looking forward to seeing our returning members as well! Join us at our Kick-off Meeting on September 10th to meet the new members and get back together with the team.</p>
                   <ul class="about-preview">
-                    <li><strong>Action:</strong> Bring a friend; join the mailing list.</li>
-                    <li><strong>Action:</strong> Subscribe to the Calendar.</li>
+                    <li><strong>Action:</strong> Bring a friend!</li>
+                    <li><strong>Action:</strong> Be sure to be subscribed to the club calendar for real time updates on meeting locations.</li>
                   </ul>
                   <div class="cta-row">
                     <a class="link-chip" href="calendar.html">Calendar →</a>
-                    <a class="link-chip" href="https://docs.google.com/forms/d/e/1FAIpQLSftE0vf0Nd4kSeQlCfj6eTI9HnBrKXgAMVMU_faWM5XICtptw/viewform?usp=dialog" target="_blank" rel="noopener">Mailing List →</a>
-                  </div>
-                </article>
-              </div>
-
-              <!-- Standard announcements -->
-              <div class="announce">
-                <article class="target-card">
-                  <span class="pill open">Sep 9</span>
-                  <h4>Case Workshop Sign-ups</h4>
-                  <p class="about-preview">Reserve a 15-minute slot during Wednesday’s Training to workshop a case.</p>
-                  <ul class="about-preview">
-                    <li><strong>Action:</strong> Come with a 1-paragraph case shell.</li>
-                  </ul>
-                  <div class="cta-row">
-                    <a class="link-chip" href="calendar.html">See meeting event →</a>
-                  </div>
-                </article>
-              </div>
-
-              <div class="announce">
-                <article class="target-card">
-                  <span class="pill tentative">Sep 15</span>
-                  <h4>Tournament A Travel Notes</h4>
-                  <p class="about-preview">Packing list, call times, and contacts will post on the Tournaments page.</p>
-                  <ul class="about-preview">
-                    <li><strong>Action:</strong> Check ID validity; bring water bottle.</li>
-                  </ul>
-                  <div class="cta-row">
-                    <a class="link-chip" href="tournaments.html">Tournaments →</a>
                   </div>
                 </article>
               </div>


### PR DESCRIPTION
## Summary
- Replace all announcements on members dashboard with single Fall Welcome notice dated Sep 10.
- New announcement invites members to Kick-off Meeting with action items and calendar link.

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68c0e00dc38483228c242fc570112c59