### PR TITLE
Refocus upcoming travel on Boston University novice tournament

### DIFF
--- a/index.html
+++ b/index.html
@@ -402,12 +402,12 @@
     <section class="featured-wrap reveal" id="featured">
       <div class="featured-card">
         <div>
-          <h3 class="about-header" style="margin-bottom:.4rem;">Featured: Bates</h3>
+          <h3 class="about-header" style="margin-bottom:.4rem;">Featured: Boston University Novice</h3>
           <div class="featured-meta">
-            <span class="chip">Sep 19–20</span>
-            <span class="chip">Lewiston, ME</span>
+            <span class="chip">Dates TBD</span>
+            <span class="chip">Boston, MA</span>
           </div>
-          <p class="about-preview" style="margin:.25rem 0 0;">Travel, reg, and lodging covered. Details coming soon.</p>
+          <p class="about-preview" style="margin:.25rem 0 0;">Tentative first travel of the semester. Novice-only; sign-ups pending final details.</p>
           <div class="cta-row" style="margin-top:.6rem;">
             <a class="link-chip" href="tournaments.html">Event details →</a>
           </div>
@@ -424,21 +424,11 @@
       <div class="h-scroll">
         <article class="event-card">
           <div class="event-head">
-            <h4>Tufts</h4>
-            <span class="pill tentative">Tentative</span>
-          </div>
-          <p class="event-meta">Sep 26–27 · Medford, MA</p>
-          <p class="event-note">Details coming soon.</p>
-          <a class="link-chip" href="tournaments.html">Details →</a>
-        </article>
-
-        <article class="event-card">
-          <div class="event-head">
             <h4>Boston University</h4>
             <span class="pill tentative">Tentative</span>
           </div>
-          <p class="event-meta">Oct 3–4 · Boston, MA</p>
-          <p class="event-note">Novice tournament.</p>
+          <p class="event-meta">Dates TBD · Boston, MA</p>
+          <p class="event-note">Novice tournament. Sign-ups pending final details.</p>
           <a class="link-chip" href="tournaments.html">Details →</a>
         </article>
 

--- a/join.html
+++ b/join.html
@@ -415,7 +415,7 @@
           <ul>
             <li>Kickoff lessons begin</li>
             <li>First scrim night</li>
-              <li>Travel: Bates (tentative); Tufts (tentative)</li>
+              <li>Travel: Prep for Boston University Novice (tentative)</li>
           </ul>
           <div class="cta-row"><a class="link-chip" href="calendar.html">Open calendar →</a></div>
         </div>

--- a/members.html
+++ b/members.html
@@ -286,17 +286,17 @@
 
           <!-- B) September tournaments overview (sharper separation + bigger headers) -->
           <div class="dash-card accent-warn span-5">
-            <h3 class="about-header" style="margin-top:.1rem;">September Tournaments  -  Overview</h3>
+            <h3 class="about-header" style="margin-top:.1rem;">Upcoming Travel  -  Overview</h3>
             <p class="about-preview" style="margin-bottom:.75rem;">
-              Expect 2–3 weekend tournaments. Sign-ups open ~10–12 days prior; pairs posted the week-of; travel covered.
+              First stop: Boston University Novice (tentative). Harvard and Brown follow later in the month. Sign-ups open ~10–12 days prior once details are confirmed.
             </p>
 
             <div class="targets-grid overview">
               <article class="target-card">
                 <span class="pill tentative">Tentative</span>
-                <div class="chip-row"><span class="chip">Sep 19–20</span><span class="chip">Bates</span></div>
-                <h3>Bates</h3>
-                <p class="about-preview" style="margin:.55rem 0 .65rem;">Judges needed: TBD</p>
+                <div class="chip-row"><span class="chip">Dates TBD</span><span class="chip">Boston University</span></div>
+                <h3>Boston University</h3>
+                <p class="about-preview" style="margin:.55rem 0 .65rem;">Novice tournament; sign-ups pending.</p>
                 <div class="cta-row">
                   <a class="link-chip" href="tournaments.html">Details →</a>
                   <a class="link-chip" href="calendar.html">Calendar →</a>
@@ -305,9 +305,20 @@
 
               <article class="target-card">
                 <span class="pill tentative">Tentative</span>
-                <div class="chip-row"><span class="chip">Sep 26–27</span><span class="chip">Tufts</span></div>
-                <h3>Tufts</h3>
-                <p class="about-preview" style="margin:.55rem 0 .65rem;">Judges needed: TBD</p>
+                <div class="chip-row"><span class="chip">Oct 10–11</span><span class="chip">Harvard</span></div>
+                <h3>Harvard</h3>
+                <p class="about-preview" style="margin:.55rem 0 .65rem;">Includes APDA meeting.</p>
+                <div class="cta-row">
+                  <a class="link-chip" href="tournaments.html">Details →</a>
+                  <a class="link-chip" href="calendar.html">Calendar →</a>
+                </div>
+              </article>
+
+              <article class="target-card">
+                <span class="pill tentative">Tentative</span>
+                <div class="chip-row"><span class="chip">Oct 24–25</span><span class="chip">Brown</span></div>
+                <h3>Brown</h3>
+                <p class="about-preview" style="margin:.55rem 0 .65rem;">Details to be announced.</p>
                 <div class="cta-row">
                   <a class="link-chip" href="tournaments.html">Details →</a>
                   <a class="link-chip" href="calendar.html">Calendar →</a>

--- a/tournaments.html
+++ b/tournaments.html
@@ -243,7 +243,7 @@
       <div class="feature-card">
         <div class="feature-left">
           <div class="event-head">
-            <h3>Bates</h3>
+            <h3>Boston University</h3>
             <span class="pill tentative">Tentative</span>
           </div>
           <div class="event-badges">
@@ -255,20 +255,20 @@
             </span>
           </div>
           <div class="meta">
-            <span class="chip">Bates College</span>
-            <span class="chip">Sep 19–20</span>
+            <span class="chip">Novice Tournament</span>
+            <span class="chip">Dates TBD</span>
           </div>
-          <p class="muted">Details coming soon.</p>
+          <p class="muted">Our first planned travel of the season. Sign-ups, travel, and lodging details are not yet confirmed.</p>
           <ul class="section-list" style="margin-top:.6rem;">
-            <li><strong>Interest form closes:</strong> TBD</li>
-            <li><strong>Travel window:</strong> TBD</li>
+            <li><strong>Interest form:</strong> Not yet open</li>
+            <li><strong>Division:</strong> Novice-only field</li>
             <li><strong>Funding:</strong> PDU covers travel, registration, lodging.</li>
           </ul>
           <div class="cta-row" style="margin-top:.75rem;">
             <a class="link-chip" href="calendar.html">Add/See on Calendar →</a>
             <a class="link-chip" href="https://drive.google.com/drive/folders/1SIot57czQp_hxY6Bx38I_SN4deVhbvDo?usp=drive_link" target="_blank" rel="noopener">TID (Drive) →</a>
           </div>
-          <p class="note">Sign up to debate <em>or</em> judge  -  choose your role in the form.</p>
+          <p class="note">Sign-ups will go live once details are finalized. Let us know if you want to debate or judge.</p>
         </div>
 
         <aside class="feature-right">
@@ -277,7 +277,7 @@
             <li>5 prelim rounds, then break to elims</li>
             <li>Meals typically provided by host</li>
             <li>Pack formal casual; bring photo ID</li>
-            <li>Equity brief at assembly (CWs, opt-outs)</li>
+            <li>Novices only—great first travel opportunity</li>
           </ul>
         </aside>
       </div>
@@ -287,56 +287,6 @@
     <section class="glass-card reveal" id="upcoming">
       <h3 class="about-header">Upcoming Targets</h3>
       <div class="targets-grid" role="list">
-        <!-- Bates -->
-        <article class="target-card" role="listitem">
-          <div class="event-head">
-            <h4>Bates</h4>
-            <span class="pill tentative">Tentative</span>
-          </div>
-          <div class="event-badges">
-            <span class="badge-need" data-judges-needed="tbd" title="Estimated judges needed">
-              <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
-                <path d="M7.5 7.5l4 4 5-5-4-4-5 5zm-1.4 1.4l-1.1 3.3 3.2-1.2 8-8-2.1-2.1-8 8zM3 21h18v-2H3v2z"/>
-              </svg>
-              <span class="badge-text">Judges needed: <strong class="need-count">TBD</strong></span>
-            </span>
-          </div>
-          <div class="meta">
-            <span class="chip">Bates College</span>
-            <span class="chip">Sep 19–20</span>
-          </div>
-          <p class="about-preview" style="margin:.25rem 0 .4rem;">Details to be announced.</p>
-          <div class="cta-row">
-            <a class="link-chip" href="calendar.html">Calendar →</a>
-            <a class="link-chip" href="https://drive.google.com/drive/folders/1SIot57czQp_hxY6Bx38I_SN4deVhbvDo?usp=drive_link" target="_blank" rel="noopener">TID →</a>
-          </div>
-        </article>
-
-        <!-- Tufts -->
-        <article class="target-card" role="listitem">
-          <div class="event-head">
-            <h4>Tufts</h4>
-            <span class="pill tentative">Tentative</span>
-          </div>
-          <div class="event-badges">
-            <span class="badge-need" data-judges-needed="tbd" title="Estimated judges needed">
-              <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
-                <path d="M7.5 7.5l4 4 5-5-4-4-5 5zm-1.4 1.4l-1.1 3.3 3.2-1.2 8-8-2.1-2.1-8 8zM3 21h18v-2H3v2z"/>
-              </svg>
-              <span class="badge-text">Judges needed: <strong class="need-count">TBD</strong></span>
-            </span>
-          </div>
-          <div class="meta">
-            <span class="chip">Tufts University</span>
-            <span class="chip">Sep 26–27</span>
-          </div>
-          <p class="about-preview" style="margin:.25rem 0 .4rem;">Details to be announced.</p>
-          <div class="cta-row">
-            <a class="link-chip" href="calendar.html">Calendar →</a>
-            <a class="link-chip" href="https://drive.google.com/drive/folders/1SIot57czQp_hxY6Bx38I_SN4deVhbvDo?usp=drive_link" target="_blank" rel="noopener">TID →</a>
-          </div>
-        </article>
-
         <!-- Boston University (Novice Tournament) -->
         <article class="target-card" role="listitem">
           <div class="event-head">
@@ -353,9 +303,9 @@
           </div>
           <div class="meta">
             <span class="chip">Novice Tournament</span>
-            <span class="chip">Oct 3–4</span>
+            <span class="chip">Dates TBD</span>
           </div>
-          <p class="about-preview" style="margin:.25rem 0 .4rem;">Novice tournament.</p>
+          <p class="about-preview" style="margin:.25rem 0 .4rem;">First planned travel. Expect a novice-only field; sign-ups will open once details land.</p>
           <div class="cta-row">
             <a class="link-chip" href="calendar.html">Calendar →</a>
             <a class="link-chip" href="https://drive.google.com/drive/folders/1SIot57czQp_hxY6Bx38I_SN4deVhbvDo?usp=drive_link" target="_blank" rel="noopener">TID →</a>


### PR DESCRIPTION
## Summary
- replace the Bates and Tufts references with a tentative Boston University novice feature across the tournaments and home pages
- update the members dashboard overview to highlight Boston University, Harvard, and Brown as the early travel slate
- adjust the join page month-by-month callouts to reflect preparing for Boston University instead of Bates/Tufts

## Testing
- No automated tests were run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68c85d02c66c832286c4b336e1a629ab