### PR TITLE
Update Boston University tournament dates to Oct 3–4

### DIFF
--- a/index.html
+++ b/index.html
@@ -404,7 +404,7 @@
         <div>
           <h3 class="about-header" style="margin-bottom:.4rem;">Featured: Boston University Novice</h3>
           <div class="featured-meta">
-            <span class="chip">Dates TBD</span>
+            <span class="chip">Oct 3–4</span>
             <span class="chip">Boston, MA</span>
           </div>
           <p class="about-preview" style="margin:.25rem 0 0;">Tentative first travel of the semester. Novice-only; sign-ups pending final details.</p>
@@ -427,7 +427,7 @@
             <h4>Boston University</h4>
             <span class="pill tentative">Tentative</span>
           </div>
-          <p class="event-meta">Dates TBD · Boston, MA</p>
+          <p class="event-meta">Oct 3–4 · Boston, MA</p>
           <p class="event-note">Novice tournament. Sign-ups pending final details.</p>
           <a class="link-chip" href="tournaments.html">Details →</a>
         </article>

--- a/join.html
+++ b/join.html
@@ -415,7 +415,7 @@
           <ul>
             <li>Kickoff lessons begin</li>
             <li>First scrim night</li>
-              <li>Travel: Prep for Boston University Novice (tentative)</li>
+              <li>Travel: Prep for Boston University Novice (Oct 3–4, tentative)</li>
           </ul>
           <div class="cta-row"><a class="link-chip" href="calendar.html">Open calendar →</a></div>
         </div>
@@ -423,7 +423,7 @@
           <h4>October</h4>
           <ul>
             <li>Casebuilding workshop</li>
-              <li>Travel: Boston University Novice (tentative); Harvard (APDA Meeting, tentative); Brown (tentative)</li>
+              <li>Travel: Boston University Novice (Oct 3–4, tentative); Harvard (APDA Meeting, tentative); Brown (tentative)</li>
             <li>Novice spotlight night</li>
           </ul>
           <div class="cta-row"><a class="link-chip" href="calendar.html">Open calendar →</a></div>

--- a/members.html
+++ b/members.html
@@ -249,7 +249,7 @@
       <div class="dash-card accent-info span-12">
         <div class="stat-row">
           <span class="stat-chip"><i class="dot purple blink"></i> <span id="memberCountdown">Calculating next meeting…</span></span>
-          <span class="stat-chip"><i class="dot purple"></i> Next tournament: <strong>TBD</strong></span>
+          <span class="stat-chip"><i class="dot purple"></i> Next tournament: <strong>Oct 3–4</strong></span>
           <a class="stat-chip attendance-link" href="https://forms.gle/HEqqch1fvxPHEvKt6" target="_blank" rel="noopener">
             <i class="dot green"></i>
             Mark your attendance →
@@ -288,13 +288,13 @@
           <div class="dash-card accent-warn span-5">
             <h3 class="about-header" style="margin-top:.1rem;">Upcoming Travel  -  Overview</h3>
             <p class="about-preview" style="margin-bottom:.75rem;">
-              First stop: Boston University Novice (tentative). Harvard and Brown follow later in the month. Sign-ups open ~10–12 days prior once details are confirmed.
+              First stop: Boston University Novice (Oct 3–4, tentative). Harvard and Brown follow later in the month. Sign-ups open ~10–12 days prior once details are confirmed.
             </p>
 
             <div class="targets-grid overview">
               <article class="target-card">
                 <span class="pill tentative">Tentative</span>
-                <div class="chip-row"><span class="chip">Dates TBD</span><span class="chip">Boston University</span></div>
+                <div class="chip-row"><span class="chip">Oct 3–4</span><span class="chip">Boston University</span></div>
                 <h3>Boston University</h3>
                 <p class="about-preview" style="margin:.55rem 0 .65rem;">Novice tournament; sign-ups pending.</p>
                 <div class="cta-row">
@@ -336,7 +336,7 @@
             <h4>October</h4>
             <ul>
               <li>Mon/Wed meetings · 7:00 PM</li>
-              <li>Travel: Boston University Novice · Harvard (APDA Meeting) · Brown</li>
+              <li>Travel: Boston University Novice (Oct 3–4) · Harvard (APDA Meeting) · Brown</li>
             </ul>
             <div class="cta-row"><a class="link-chip" href="tournaments.html#october">See slate →</a></div>
           </div>

--- a/tournaments.html
+++ b/tournaments.html
@@ -256,7 +256,7 @@
           </div>
           <div class="meta">
             <span class="chip">Novice Tournament</span>
-            <span class="chip">Dates TBD</span>
+            <span class="chip">Oct 3–4</span>
           </div>
           <p class="muted">Our first planned travel of the season. Sign-ups, travel, and lodging details are not yet confirmed.</p>
           <ul class="section-list" style="margin-top:.6rem;">
@@ -303,7 +303,7 @@
           </div>
           <div class="meta">
             <span class="chip">Novice Tournament</span>
-            <span class="chip">Dates TBD</span>
+            <span class="chip">Oct 3–4</span>
           </div>
           <p class="about-preview" style="margin:.25rem 0 .4rem;">First planned travel. Expect a novice-only field; sign-ups will open once details land.</p>
           <div class="cta-row">


### PR DESCRIPTION
## Summary
- update all Boston University tournament references to list the Oct 3–4 date across the site

## Testing
- not run (static content update)


------
https://chatgpt.com/codex/tasks/task_e_68c8605d4a68832294bb787dec9486b4