### PR TITLE
Update featured novice tournament to Johns Hopkins

### DIFF
--- a/index.html
+++ b/index.html
@@ -402,12 +402,13 @@
     <section class="featured-wrap reveal" id="featured">
       <div class="featured-card">
         <div>
-          <h3 class="about-header" style="margin-bottom:.4rem;">Featured: Boston University Novice</h3>
+          <h3 class="about-header" style="margin-bottom:.4rem;">Featured: Johns Hopkins Novice (APDA)</h3>
           <div class="featured-meta">
             <span class="chip">Oct 3–4</span>
-            <span class="chip">Boston, MA</span>
+            <span class="chip">Baltimore, MD</span>
+            <span class="chip">Motion Tournament</span>
           </div>
-          <p class="about-preview" style="margin:.25rem 0 0;">Tentative first travel of the semester. Novice-only; sign-ups pending final details.</p>
+          <p class="about-preview" style="margin:.25rem 0 0;">APDA novice weekend stop hosted by Johns Hopkins UDC on the Homewood campus. Motion tournament running the same weekend as BU and Swarthmore novice events; sign-ups pending final details.</p>
           <div class="cta-row" style="margin-top:.6rem;">
             <a class="link-chip" href="tournaments.html">Event details →</a>
           </div>
@@ -424,11 +425,11 @@
       <div class="h-scroll">
         <article class="event-card">
           <div class="event-head">
-            <h4>Boston University</h4>
+            <h4>Johns Hopkins Novice (APDA)</h4>
             <span class="pill tentative">Tentative</span>
           </div>
-          <p class="event-meta">Oct 3–4 · Boston, MA</p>
-          <p class="event-note">Novice tournament. Sign-ups pending final details.</p>
+          <p class="event-meta">Oct 3–4 · Baltimore, MD</p>
+          <p class="event-note">Motion tournament during APDA novice weekend (same weekend as BU and Swarthmore novice events). Watch APDA’s schedule and the 25–26 sheet for updates.</p>
           <a class="link-chip" href="tournaments.html">Details →</a>
         </article>
 

--- a/join.html
+++ b/join.html
@@ -415,7 +415,7 @@
           <ul>
             <li>Kickoff lessons begin</li>
             <li>First scrim night</li>
-              <li>Travel: Prep for Boston University Novice (Oct 3–4, tentative)</li>
+              <li>Travel: Prep for Johns Hopkins Novice (APDA) — APDA novice weekend motion tournament Oct 3–4 in Baltimore (tentative)</li>
           </ul>
           <div class="cta-row"><a class="link-chip" href="calendar.html">Open calendar →</a></div>
         </div>
@@ -423,7 +423,7 @@
           <h4>October</h4>
           <ul>
             <li>Casebuilding workshop</li>
-              <li>Travel: Boston University Novice (Oct 3–4, tentative); Harvard (APDA Meeting, tentative); Brown (tentative)</li>
+              <li>Travel: Johns Hopkins Novice (APDA) — APDA novice weekend motion tournament Oct 3–4 in Baltimore (tentative); Harvard (APDA Meeting, tentative); Brown (tentative)</li>
             <li>Novice spotlight night</li>
           </ul>
           <div class="cta-row"><a class="link-chip" href="calendar.html">Open calendar →</a></div>

--- a/members.html
+++ b/members.html
@@ -288,15 +288,15 @@
           <div class="dash-card accent-warn span-5">
             <h3 class="about-header" style="margin-top:.1rem;">Upcoming Travel  -  Overview</h3>
             <p class="about-preview" style="margin-bottom:.75rem;">
-              First stop: Boston University Novice (Oct 3–4, tentative). Harvard and Brown follow later in the month. Sign-ups open ~10–12 days prior once details are confirmed.
+              First stop: Johns Hopkins Novice (APDA) — APDA novice weekend motion tournament Oct 3–4 in Baltimore (tentative). Harvard and Brown follow later in the month. Sign-ups open ~10–12 days prior once details are confirmed.
             </p>
 
             <div class="targets-grid overview">
               <article class="target-card">
                 <span class="pill tentative">Tentative</span>
-                <div class="chip-row"><span class="chip">Oct 3–4</span><span class="chip">Boston University</span></div>
-                <h3>Boston University</h3>
-                <p class="about-preview" style="margin:.55rem 0 .65rem;">Novice tournament; sign-ups pending.</p>
+                <div class="chip-row"><span class="chip">Oct 3–4</span><span class="chip">Johns Hopkins Novice (APDA)</span></div>
+                <h3>Johns Hopkins Novice (APDA)</h3>
+                <p class="about-preview" style="margin:.55rem 0 .65rem;">APDA novice weekend motion tournament on Johns Hopkins’ Homewood campus; details via APDA schedule and 25–26 sheet.</p>
                 <div class="cta-row">
                   <a class="link-chip" href="tournaments.html">Details →</a>
                   <a class="link-chip" href="calendar.html">Calendar →</a>
@@ -336,7 +336,7 @@
             <h4>October</h4>
             <ul>
               <li>Mon/Wed meetings · 7:00 PM</li>
-              <li>Travel: Boston University Novice (Oct 3–4) · Harvard (APDA Meeting) · Brown</li>
+              <li>Travel: Johns Hopkins Novice (APDA) — APDA novice weekend motion tournament Oct 3–4 in Baltimore · Harvard (APDA Meeting) · Brown</li>
             </ul>
             <div class="cta-row"><a class="link-chip" href="tournaments.html#october">See slate →</a></div>
           </div>

--- a/tournaments.html
+++ b/tournaments.html
@@ -243,7 +243,7 @@
       <div class="feature-card">
         <div class="feature-left">
           <div class="event-head">
-            <h3>Boston University</h3>
+            <h3>Johns Hopkins Novice (APDA)</h3>
             <span class="pill tentative">Tentative</span>
           </div>
           <div class="event-badges">
@@ -255,29 +255,30 @@
             </span>
           </div>
           <div class="meta">
-            <span class="chip">Novice Tournament</span>
+            <span class="chip">Motion Tournament</span>
             <span class="chip">Oct 3–4</span>
           </div>
-          <p class="muted">Our first planned travel of the season. Sign-ups, travel, and lodging details are not yet confirmed.</p>
+          <p class="muted">Part of APDA’s annual novice weekend and hosted by the Johns Hopkins Undergraduate Debate Council on the Homewood campus in Baltimore. Runs alongside BU Novice and Swarthmore Novice on the APDA calendar.</p>
           <ul class="section-list" style="margin-top:.6rem;">
             <li><strong>Interest form:</strong> Not yet open</li>
-            <li><strong>Division:</strong> Novice-only field</li>
+            <li><strong>Division:</strong> Novice-only field; APDA motion sets</li>
             <li><strong>Funding:</strong> PDU covers travel, registration, lodging.</li>
+            <li><strong>Details:</strong> APDA’s Schedule page and the public 25–26 Scheduling Sheet already list the event; expect the full invite on the APDA Forum (login required).</li>
           </ul>
           <div class="cta-row" style="margin-top:.75rem;">
             <a class="link-chip" href="calendar.html">Add/See on Calendar →</a>
             <a class="link-chip" href="https://drive.google.com/drive/folders/1SIot57czQp_hxY6Bx38I_SN4deVhbvDo?usp=drive_link" target="_blank" rel="noopener">TID (Drive) →</a>
           </div>
-          <p class="note">Sign-ups will go live once details are finalized. Let us know if you want to debate or judge.</p>
+          <p class="note">Sign-ups will go live once final details post. Let us know if you want to debate or judge so we can track interest early.</p>
         </div>
 
         <aside class="feature-right">
           <h4>What to expect</h4>
           <ul class="section-list">
-            <li>5 prelim rounds, then break to elims</li>
-            <li>Meals typically provided by host</li>
-            <li>Pack formal casual; bring photo ID</li>
-            <li>Novices only—great first travel opportunity</li>
+            <li>Hosted on Johns Hopkins’ Homewood campus in Baltimore, MD</li>
+            <li>Runs alongside BU Novice and Swarthmore during novice weekend</li>
+            <li>5 prelim rounds using APDA motion sets, then break to elims</li>
+            <li>Meals typically provided by host; pack formal casual and bring photo ID</li>
           </ul>
         </aside>
       </div>
@@ -287,10 +288,10 @@
     <section class="glass-card reveal" id="upcoming">
       <h3 class="about-header">Upcoming Targets</h3>
       <div class="targets-grid" role="list">
-        <!-- Boston University (Novice Tournament) -->
+        <!-- Johns Hopkins Novice (APDA) -->
         <article class="target-card" role="listitem">
           <div class="event-head">
-            <h4>Boston University</h4>
+            <h4>Johns Hopkins Novice (APDA)</h4>
             <span class="pill tentative">Tentative</span>
           </div>
           <div class="event-badges">
@@ -302,10 +303,10 @@
             </span>
           </div>
           <div class="meta">
-            <span class="chip">Novice Tournament</span>
+            <span class="chip">Motion Tournament</span>
             <span class="chip">Oct 3–4</span>
           </div>
-          <p class="about-preview" style="margin:.25rem 0 .4rem;">First planned travel. Expect a novice-only field; sign-ups will open once details land.</p>
+          <p class="about-preview" style="margin:.25rem 0 .4rem;">Motion tournament hosted by Johns Hopkins UDC on the Homewood campus; part of APDA’s novice weekend alongside BU and Swarthmore. Watch APDA’s Schedule and 25–26 sheet for updates.</p>
           <div class="cta-row">
             <a class="link-chip" href="calendar.html">Calendar →</a>
             <a class="link-chip" href="https://drive.google.com/drive/folders/1SIot57czQp_hxY6Bx38I_SN4deVhbvDo?usp=drive_link" target="_blank" rel="noopener">TID →</a>


### PR DESCRIPTION
## Summary
- replace Boston University novice references across the site with Johns Hopkins Novice (APDA)
- highlight that the event is part of APDA novice weekend, hosted on the Homewood campus, and run as a motion tournament
- point readers to APDA schedule resources and the 25–26 sheet for event details

## Testing
- not run (static content changes)


------
https://chatgpt.com/codex/tasks/task_e_68c89c76a3088322b621e9509f3f06ab