### PR TITLE
Highlight open Johns Hopkins sign-ups across site

### DIFF
--- a/index.html
+++ b/index.html
@@ -408,13 +408,14 @@
             <span class="chip">Baltimore, MD</span>
             <span class="chip">Motion Tournament</span>
           </div>
-          <p class="about-preview" style="margin:.25rem 0 0;">APDA novice weekend stop hosted by Johns Hopkins UDC on the Homewood campus. Motion tournament running the same weekend as BU and Swarthmore novice events; sign-ups pending final details.</p>
+          <p class="about-preview" style="margin:.25rem 0 0;">APDA novice weekend stop hosted by Johns Hopkins UDC on the Homewood campus. Sign-ups are <strong>OPEN</strong>: <a href="https://forms.gle/sEoHBcDgiaGoPA5T8" target="_blank" rel="noopener">submit the form →</a>.</p>
           <div class="cta-row" style="margin-top:.6rem;">
             <a class="link-chip" href="tournaments.html">Event details →</a>
+            <a class="link-chip" href="https://forms.gle/sEoHBcDgiaGoPA5T8" target="_blank" rel="noopener">Sign up →</a>
           </div>
         </div>
         <div class="featured-side">
-          <span class="pill tentative">Tentative</span>
+          <span class="pill open">Sign-ups open</span>
         </div>
       </div>
     </section>
@@ -426,11 +427,14 @@
         <article class="event-card">
           <div class="event-head">
             <h4>Johns Hopkins Novice (APDA)</h4>
-            <span class="pill tentative">Tentative</span>
+            <span class="pill open">Sign-ups open</span>
           </div>
           <p class="event-meta">Oct 3–4 · Baltimore, MD</p>
-          <p class="event-note">Motion tournament during APDA novice weekend (same weekend as BU and Swarthmore novice events). Watch APDA’s schedule and the 25–26 sheet for updates.</p>
-          <a class="link-chip" href="tournaments.html">Details →</a>
+          <p class="event-note">Motion tournament during APDA novice weekend hosted by Johns Hopkins UDC. Sign-ups are <strong>OPEN</strong>: <a href="https://forms.gle/sEoHBcDgiaGoPA5T8" target="_blank" rel="noopener">complete the form →</a>.</p>
+          <div class="cta-row" style="gap:.4rem;">
+            <a class="link-chip" href="tournaments.html">Details →</a>
+            <a class="link-chip" href="https://forms.gle/sEoHBcDgiaGoPA5T8" target="_blank" rel="noopener">Sign up →</a>
+          </div>
         </article>
 
         <article class="event-card">

--- a/join.html
+++ b/join.html
@@ -415,7 +415,7 @@
           <ul>
             <li>Kickoff lessons begin</li>
             <li>First scrim night</li>
-              <li>Travel: Prep for Johns Hopkins Novice (APDA) — APDA novice weekend motion tournament Oct 3–4 in Baltimore (tentative)</li>
+              <li>Travel: Prep for Johns Hopkins Novice (APDA) — APDA novice weekend motion tournament Oct 3–4 in Baltimore. <strong>Sign-ups are OPEN:</strong> <a href="https://forms.gle/sEoHBcDgiaGoPA5T8" target="_blank" rel="noopener">Submit the form →</a></li>
           </ul>
           <div class="cta-row"><a class="link-chip" href="calendar.html">Open calendar →</a></div>
         </div>
@@ -423,7 +423,7 @@
           <h4>October</h4>
           <ul>
             <li>Casebuilding workshop</li>
-              <li>Travel: Johns Hopkins Novice (APDA) — APDA novice weekend motion tournament Oct 3–4 in Baltimore (tentative); Harvard (APDA Meeting, tentative); Brown (tentative)</li>
+              <li>Travel: Johns Hopkins Novice (APDA) — APDA novice weekend motion tournament Oct 3–4 in Baltimore; <strong>Sign-ups are OPEN</strong>: <a href="https://forms.gle/sEoHBcDgiaGoPA5T8" target="_blank" rel="noopener">Submit the form →</a>; Harvard (APDA Meeting, tentative); Brown (tentative)</li>
             <li>Novice spotlight night</li>
           </ul>
           <div class="cta-row"><a class="link-chip" href="calendar.html">Open calendar →</a></div>

--- a/members.html
+++ b/members.html
@@ -288,18 +288,19 @@
           <div class="dash-card accent-warn span-5">
             <h3 class="about-header" style="margin-top:.1rem;">Upcoming Travel  -  Overview</h3>
             <p class="about-preview" style="margin-bottom:.75rem;">
-              First stop: Johns Hopkins Novice (APDA) — APDA novice weekend motion tournament Oct 3–4 in Baltimore (tentative). Harvard and Brown follow later in the month. Sign-ups open ~10–12 days prior once details are confirmed.
+              First stop: Johns Hopkins Novice (APDA) — APDA novice weekend motion tournament Oct 3–4 in Baltimore. Sign-ups are <strong>OPEN</strong>: <a href="https://forms.gle/sEoHBcDgiaGoPA5T8" target="_blank" rel="noopener">submit the form →</a>. Harvard and Brown follow later in the month.
             </p>
 
             <div class="targets-grid overview">
               <article class="target-card">
-                <span class="pill tentative">Tentative</span>
+                <span class="pill open">Sign-ups open</span>
                 <div class="chip-row"><span class="chip">Oct 3–4</span><span class="chip">Johns Hopkins Novice (APDA)</span></div>
                 <h3>Johns Hopkins Novice (APDA)</h3>
-                <p class="about-preview" style="margin:.55rem 0 .65rem;">APDA novice weekend motion tournament on Johns Hopkins’ Homewood campus; details via APDA schedule and 25–26 sheet.</p>
+                <p class="about-preview" style="margin:.55rem 0 .65rem;">APDA novice weekend motion tournament on Johns Hopkins’ Homewood campus. Sign-ups are <strong>OPEN</strong>: <a href="https://forms.gle/sEoHBcDgiaGoPA5T8" target="_blank" rel="noopener">complete the form →</a>.</p>
                 <div class="cta-row">
                   <a class="link-chip" href="tournaments.html">Details →</a>
                   <a class="link-chip" href="calendar.html">Calendar →</a>
+                  <a class="link-chip" href="https://forms.gle/sEoHBcDgiaGoPA5T8" target="_blank" rel="noopener">Sign up →</a>
                 </div>
               </article>
 

--- a/tournaments.html
+++ b/tournaments.html
@@ -244,7 +244,7 @@
         <div class="feature-left">
           <div class="event-head">
             <h3>Johns Hopkins Novice (APDA)</h3>
-            <span class="pill tentative">Tentative</span>
+            <span class="pill open">Sign-ups open</span>
           </div>
           <div class="event-badges">
             <span class="badge-need" data-judges-needed="tbd" title="Estimated judges needed">
@@ -258,9 +258,9 @@
             <span class="chip">Motion Tournament</span>
             <span class="chip">Oct 3–4</span>
           </div>
-          <p class="muted">Part of APDA’s annual novice weekend and hosted by the Johns Hopkins Undergraduate Debate Council on the Homewood campus in Baltimore. Runs alongside BU Novice and Swarthmore Novice on the APDA calendar.</p>
+          <p class="muted">Part of APDA’s annual novice weekend and hosted by the Johns Hopkins Undergraduate Debate Council on the Homewood campus in Baltimore.</p>
           <ul class="section-list" style="margin-top:.6rem;">
-            <li><strong>Interest form:</strong> Not yet open</li>
+            <li><strong>Sign-ups:</strong> <strong>OPEN</strong> — <a href="https://forms.gle/sEoHBcDgiaGoPA5T8" target="_blank" rel="noopener">Submit the interest form →</a></li>
             <li><strong>Division:</strong> Novice-only field; APDA motion sets</li>
             <li><strong>Funding:</strong> PDU covers travel, registration, lodging.</li>
             <li><strong>Details:</strong> APDA’s Schedule page and the public 25–26 Scheduling Sheet already list the event; expect the full invite on the APDA Forum (login required).</li>
@@ -268,15 +268,16 @@
           <div class="cta-row" style="margin-top:.75rem;">
             <a class="link-chip" href="calendar.html">Add/See on Calendar →</a>
             <a class="link-chip" href="https://drive.google.com/drive/folders/1SIot57czQp_hxY6Bx38I_SN4deVhbvDo?usp=drive_link" target="_blank" rel="noopener">TID (Drive) →</a>
+            <a class="link-chip" href="https://forms.gle/sEoHBcDgiaGoPA5T8" target="_blank" rel="noopener">Sign up →</a>
           </div>
-          <p class="note">Sign-ups will go live once final details post. Let us know if you want to debate or judge so we can track interest early.</p>
+          <p class="note">Sign-ups are OPEN: <a href="https://forms.gle/sEoHBcDgiaGoPA5T8" target="_blank" rel="noopener">complete the form</a> to tell us if you want to debate or judge.</p>
         </div>
 
         <aside class="feature-right">
           <h4>What to expect</h4>
           <ul class="section-list">
             <li>Hosted on Johns Hopkins’ Homewood campus in Baltimore, MD</li>
-            <li>Runs alongside BU Novice and Swarthmore during novice weekend</li>
+            <li>Novice-exclusive stop on APDA’s fall schedule</li>
             <li>5 prelim rounds using APDA motion sets, then break to elims</li>
             <li>Meals typically provided by host; pack formal casual and bring photo ID</li>
           </ul>
@@ -292,7 +293,7 @@
         <article class="target-card" role="listitem">
           <div class="event-head">
             <h4>Johns Hopkins Novice (APDA)</h4>
-            <span class="pill tentative">Tentative</span>
+            <span class="pill open">Sign-ups open</span>
           </div>
           <div class="event-badges">
             <span class="badge-need" data-judges-needed="tbd" title="Estimated judges needed">
@@ -306,10 +307,11 @@
             <span class="chip">Motion Tournament</span>
             <span class="chip">Oct 3–4</span>
           </div>
-          <p class="about-preview" style="margin:.25rem 0 .4rem;">Motion tournament hosted by Johns Hopkins UDC on the Homewood campus; part of APDA’s novice weekend alongside BU and Swarthmore. Watch APDA’s Schedule and 25–26 sheet for updates.</p>
+          <p class="about-preview" style="margin:.25rem 0 .4rem;">Motion tournament hosted by Johns Hopkins UDC on the Homewood campus. Sign-ups are <strong>OPEN</strong>: <a href="https://forms.gle/sEoHBcDgiaGoPA5T8" target="_blank" rel="noopener">submit the form →</a>. Watch APDA’s Schedule and 25–26 sheet for updates.</p>
           <div class="cta-row">
             <a class="link-chip" href="calendar.html">Calendar →</a>
             <a class="link-chip" href="https://drive.google.com/drive/folders/1SIot57czQp_hxY6Bx38I_SN4deVhbvDo?usp=drive_link" target="_blank" rel="noopener">TID →</a>
+            <a class="link-chip" href="https://forms.gle/sEoHBcDgiaGoPA5T8" target="_blank" rel="noopener">Sign up →</a>
           </div>
         </article>
 


### PR DESCRIPTION
## Summary
- update Johns Hopkins tournament information to remove references to other novice events and reflect that sign-ups are open across the site
- add prominent sign-up links for Johns Hopkins Novice on the tournaments, index, members, and join pages

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68c8a0c794e08322b5b4139be5429922