### PR TITLE
Update Johns Hopkins judges count and homepage CTA text

### DIFF
--- a/index.html
+++ b/index.html
@@ -283,7 +283,7 @@
       <h1 class="hero-title">Welcome to PDU · Fall 2025</h1>
       <p class="hero-sub">Train twice a week. Compete most weekends. No experience needed.</p>
       <div class="hero-ctas">
-        <a class="btn-primary" href="join.html">Click here to get started</a>
+        <a class="btn-primary" href="join.html">Click here to Join!</a>
         <a class="btn-secondary" href="members.html">I’m Returning</a>
       </div>
     </div>
@@ -308,7 +308,7 @@
       <h3>Start here: join at your own pace</h3>
       <p>Drop in on <strong>Mondays (Lessons)</strong> or <strong>Wednesdays (Training)</strong>, 7–9 PM. We’ll help you get comfortable fast.</p>
       <div class="n-actions">
-        <a class="link-chip" href="join.html">Click here to get started →</a>
+        <a class="link-chip" href="join.html">Click here to Join!</a>
         <a class="link-chip" href="beginner.html">Beginner Guide →</a>
         <a class="link-chip" href="calendar.html">Open the calendar →</a>
       </div>

--- a/tournaments.html
+++ b/tournaments.html
@@ -247,11 +247,11 @@
             <span class="pill open">Sign-ups open</span>
           </div>
           <div class="event-badges">
-            <span class="badge-need" data-judges-needed="tbd" title="Estimated judges needed">
+            <span class="badge-need" data-judges-needed="3" title="Estimated judges needed">
               <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
                 <path d="M7.5 7.5l4 4 5-5-4-4-5 5zm-1.4 1.4l-1.1 3.3 3.2-1.2 8-8-2.1-2.1-8 8zM3 21h18v-2H3v2z"/>
               </svg>
-              <span class="badge-text">Judges needed: <strong class="need-count">TBD</strong></span>
+              <span class="badge-text">Judges needed: <strong class="need-count">3</strong></span>
             </span>
           </div>
           <div class="meta">
@@ -296,11 +296,11 @@
             <span class="pill open">Sign-ups open</span>
           </div>
           <div class="event-badges">
-            <span class="badge-need" data-judges-needed="tbd" title="Estimated judges needed">
+            <span class="badge-need" data-judges-needed="3" title="Estimated judges needed">
               <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
                 <path d="M7.5 7.5l4 4 5-5-4-4-5 5zm-1.4 1.4l-1.1 3.3 3.2-1.2 8-8-2.1-2.1-8 8zM3 21h18v-2H3v2z"/>
               </svg>
-              <span class="badge-text">Judges needed: <strong class="need-count">TBD</strong></span>
+              <span class="badge-text">Judges needed: <strong class="need-count">3</strong></span>
             </span>
           </div>
           <div class="meta">


### PR DESCRIPTION
## Summary
- set the Johns Hopkins Novice tournament badges to show that three judges are needed
- update the homepage CTA chips to read "Click here to Join!"

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68c8c3803b90832289b7e209e91b4d71