### PR TITLE
Refactor nav scripts for Safari compatibility

### DIFF
--- a/about.html
+++ b/about.html
@@ -299,7 +299,9 @@
     const observer = new IntersectionObserver(entries => {
       entries.forEach(entry => entry.isIntersecting && entry.target.classList.add('reveal'));
     }, { threshold: 0.06 });
-    document.querySelectorAll('.glass-card').forEach(el => observer.observe(el));
+    for (const el of document.querySelectorAll('.glass-card')) {
+      observer.observe(el);
+    }
 
     // Measure navbar for drawer offset
     const navbar = document.getElementById('siteNavbar');
@@ -322,22 +324,24 @@
     closeBtn.addEventListener('click', closeDrawer);
     scrim.addEventListener('click', closeDrawer);
     window.addEventListener('keydown', e => { if(e.key==='Escape' && drawer.classList.contains('open')) closeDrawer(); });
-    document.querySelectorAll('.drawer-toggle').forEach(btn=>{
+    for (const btn of document.querySelectorAll('.drawer-toggle')) {
       btn.addEventListener('click',()=>{
         const ex = btn.getAttribute('aria-expanded')==='true';
         btn.setAttribute('aria-expanded', String(!ex));
         btn.nextElementSibling.classList.toggle('open');
       });
-    });
+    }
     // Desktop submenu a11y
-    document.querySelectorAll('.has-submenu').forEach(item=>{
+    for (const item of document.querySelectorAll('.has-submenu')) {
       const link=item.querySelector('.top-link');
       item.addEventListener('mouseenter',()=>link.setAttribute('aria-expanded','true'));
       item.addEventListener('mouseleave',()=>link.setAttribute('aria-expanded','false'));
       link.addEventListener('focus',()=>link.setAttribute('aria-expanded','true'));
       const sm=item.querySelector('.submenu');
-      sm?.addEventListener('keydown',e=>{ if(e.key==='Escape'){ link.focus(); link.setAttribute('aria-expanded','false'); } });
-    });
+      if(sm){
+        sm.addEventListener('keydown',e=>{ if(e.key==='Escape'){ link.focus(); link.setAttribute('aria-expanded','false'); } });
+      }
+    }
 
     // Contents drawer
     const tocDrawer = document.getElementById('tocDrawer');
@@ -363,7 +367,7 @@
     const tocLinks = [...document.querySelectorAll('.toc-list a')];
     window.addEventListener('scroll', () => {
       const y = window.scrollY + 120;
-      let current = sections[0]?.id;
+      let current = sections.length > 0 ? sections[0].id : undefined;
       for (const s of sections) { if (s.offsetTop <= y) current = s.id; }
       tocLinks.forEach(a => a.classList.toggle('active', a.getAttribute('href') === '#' + current));
     }, { passive: true });

--- a/advanced.html
+++ b/advanced.html
@@ -737,7 +737,9 @@
     const observer = new IntersectionObserver(entries => {
       entries.forEach(e => e.isIntersecting && e.target.classList.add('reveal'));
     }, { threshold: 0.06 });
-    document.querySelectorAll('.glass-card').forEach(el => observer.observe(el));
+    for (const el of document.querySelectorAll('.glass-card')) {
+      observer.observe(el);
+    }
 
     /* ==========================================================
        Navbar sizing var
@@ -764,21 +766,23 @@
     closeBtn.addEventListener('click', closeDrawer);
     scrim.addEventListener('click', closeDrawer);
     addEventListener('keydown', e => { if(e.key==='Escape' && drawer.classList.contains('open')) closeDrawer(); });
-    document.querySelectorAll('.drawer-toggle').forEach(btn=>{
+    for (const btn of document.querySelectorAll('.drawer-toggle')) {
       btn.addEventListener('click',()=>{
         const ex = btn.getAttribute('aria-expanded')==='true';
         btn.setAttribute('aria-expanded', String(!ex));
         btn.nextElementSibling.classList.toggle('open');
       });
-    });
-    document.querySelectorAll('.has-submenu').forEach(item=>{
+    }
+    for (const item of document.querySelectorAll('.has-submenu')) {
       const link=item.querySelector('.top-link');
       item.addEventListener('mouseenter',()=>link.setAttribute('aria-expanded','true'));
       item.addEventListener('mouseleave',()=>link.setAttribute('aria-expanded','false'));
       link.addEventListener('focus',()=>link.setAttribute('aria-expanded','true'));
       const sm=item.querySelector('.submenu');
-      sm?.addEventListener('keydown',e=>{ if(e.key==='Escape'){ link.focus(); link.setAttribute('aria-expanded','false'); } });
-    });
+      if(sm){
+        sm.addEventListener('keydown',e=>{ if(e.key==='Escape'){ link.focus(); link.setAttribute('aria-expanded','false'); } });
+      }
+    }
 
     /* ==========================================================
        Contents drawer:
@@ -816,7 +820,7 @@
     const tocLinks = [...document.querySelectorAll('.toc-list a')];
     addEventListener('scroll', () => {
       const y = scrollY + 120;
-      let current = sections[0]?.id;
+      let current = sections.length > 0 ? sections[0].id : undefined;
       for (const s of sections) { if (s.offsetTop <= y) current = s.id; }
       tocLinks.forEach(a => a.classList.toggle('active', a.getAttribute('href') === '#' + current));
     }, { passive: true });
@@ -824,16 +828,20 @@
     /* ==========================================================
        Expanders (keyboard accessible)
     ========================================================== */
-    document.querySelectorAll('.expander').forEach(ex=>{
+    for (const ex of document.querySelectorAll('.expander')) {
       const header = ex.querySelector('.exp-header');
-      header?.addEventListener('click', ()=> toggleExp(ex));
-      header?.addEventListener('keydown', (e)=>{ if(e.key==='Enter' || e.key===' '){ e.preventDefault(); toggleExp(ex); } });
-    });
+      if(header){
+        header.addEventListener('click', ()=> toggleExp(ex));
+        header.addEventListener('keydown', (e)=>{ if(e.key==='Enter' || e.key===' '){ e.preventDefault(); toggleExp(ex); } });
+      }
+    }
     function toggleExp(ex){
       const isOpen = ex.classList.contains('open');
       ex.classList.toggle('open', !isOpen);
       const hdr = ex.querySelector('.exp-header');
-      hdr?.setAttribute('aria-expanded', String(!isOpen));
+      if(hdr){
+        hdr.setAttribute('aria-expanded', String(!isOpen));
+      }
     }
   </script>
 </body>

--- a/assets/js/forms.js
+++ b/assets/js/forms.js
@@ -22,15 +22,17 @@
   function nowISO(){ return new Date().toISOString(); }
 
   // Attach timers for spam check
-  document.querySelectorAll('form.pdu-form').forEach(f=>{
+  for (const f of document.querySelectorAll('form.pdu-form')) {
     const start = f.querySelector('input[name="_submit_start"]');
     if(start){ start.value = String(Date.now()); }
-  });
+  }
 
   // Micro thumbs behavior
-  document.querySelectorAll('.pdu-form.micro .thumb').forEach(btn=>{
+  for (const btn of document.querySelectorAll('.pdu-form.micro .thumb')) {
     btn.addEventListener('click', ()=>{
-      document.querySelectorAll('.pdu-form.micro .thumb').forEach(b=>b.classList.remove('active'));
+      for (const b of document.querySelectorAll('.pdu-form.micro .thumb')) {
+        b.classList.remove('active');
+      }
       btn.classList.add('active');
       // ensure a hidden field stores value
       let hidden = btn.closest('form').querySelector('input[name="vote"]');
@@ -42,7 +44,7 @@
       }
       hidden.value = btn.dataset.value;
     });
-  });
+  }
 
   // Generic submit handler
   async function handleSubmit(ev){
@@ -96,12 +98,12 @@
     }
   }
 
-  document.querySelectorAll('form.pdu-form').forEach(f=>{
+  for (const f of document.querySelectorAll('form.pdu-form')) {
     f.addEventListener('submit', handleSubmit);
-  });
+  }
 
   // If a link/button includes data-topic, set the select on click
-  document.querySelectorAll('a[data-topic], button[data-topic]').forEach(el=>{
+  for (const el of document.querySelectorAll('a[data-topic], button[data-topic]')) {
     el.addEventListener('click', (e)=>{
       const topic = el.getAttribute('data-topic');
       const select = document.querySelector('#topic');
@@ -112,7 +114,7 @@
         if(form) form.dataset.topic = topic;
       }
     });
-  });
+  }
 
   // Quick drawer
   const fab = document.getElementById('feedbackFab');

--- a/beginner.html
+++ b/beginner.html
@@ -659,7 +659,9 @@
     const observer = new IntersectionObserver(entries => {
       entries.forEach(e => e.isIntersecting && e.target.classList.add('reveal'));
     }, { threshold: 0.06 });
-    document.querySelectorAll('.glass-card').forEach(el => observer.observe(el));
+    for (const el of document.querySelectorAll('.glass-card')) {
+      observer.observe(el);
+    }
 
     /* ====== Navbar sizing var ====== */
     const navbar = document.getElementById('siteNavbar');
@@ -682,21 +684,23 @@
     closeBtn.addEventListener('click', closeDrawer);
     scrim.addEventListener('click', closeDrawer);
     addEventListener('keydown', e => { if(e.key==='Escape' && drawer.classList.contains('open')) closeDrawer(); });
-    document.querySelectorAll('.drawer-toggle').forEach(btn=>{
+    for (const btn of document.querySelectorAll('.drawer-toggle')) {
       btn.addEventListener('click',()=>{
         const ex = btn.getAttribute('aria-expanded')==='true';
         btn.setAttribute('aria-expanded', String(!ex));
         btn.nextElementSibling.classList.toggle('open');
       });
-    });
-    document.querySelectorAll('.has-submenu').forEach(item=>{
+    }
+    for (const item of document.querySelectorAll('.has-submenu')) {
       const link=item.querySelector('.top-link');
       item.addEventListener('mouseenter',()=>link.setAttribute('aria-expanded','true'));
       item.addEventListener('mouseleave',()=>link.setAttribute('aria-expanded','false'));
       link.addEventListener('focus',()=>link.setAttribute('aria-expanded','true'));
       const sm=item.querySelector('.submenu');
-      sm?.addEventListener('keydown',e=>{ if(e.key==='Escape'){ link.focus(); link.setAttribute('aria-expanded','false'); } });
-    });
+      if(sm){
+        sm.addEventListener('keydown',e=>{ if(e.key==='Escape'){ link.focus(); link.setAttribute('aria-expanded','false'); } });
+      }
+    }
 
     /* ====== Contents drawer (first visit) ====== */
     const tocDrawer = document.getElementById('tocDrawer');
@@ -721,19 +725,21 @@
     const tocLinks = [...document.querySelectorAll('.toc-list a')];
     addEventListener('scroll', () => {
       const y = scrollY + 120;
-      let current = sections[0]?.id;
+      let current = sections.length > 0 ? sections[0].id : undefined;
       for (const s of sections) { if (s.offsetTop <= y) current = s.id; }
       tocLinks.forEach(a => a.classList.toggle('active', a.getAttribute('href') === '#' + current));
     }, { passive: true });
 
     /* ====== Accordions: allow only one open at a time (roles) ====== */
-    document.querySelectorAll('details.role-acc').forEach((det)=>{
+    for (const det of document.querySelectorAll('details.role-acc')) {
       det.addEventListener('toggle', ()=>{
         if(det.open){
-          document.querySelectorAll('details.role-acc').forEach(d=>{ if(d!==det) d.open=false; });
+          for (const d of document.querySelectorAll('details.role-acc')) {
+            if(d!==det) d.open=false;
+          }
         }
       });
-    });
+    }
 
     /* ====== Micro interactions ====== */
 
@@ -746,7 +752,7 @@
     function renderOrderQuiz(){
       orderQuizWrap.innerHTML = pool.map(x=> `<button class="quiz-btn" data-val="${x}">${x}</button>`).join('');
       picked = []; orderFeedback.textContent = '';
-      orderQuizWrap.querySelectorAll('button').forEach(b=>{
+      for (const b of orderQuizWrap.querySelectorAll('button')) {
         b.addEventListener('click', ()=>{
           const val = b.dataset.val;
           if(picked.includes(val)) return;
@@ -758,17 +764,17 @@
             if(!ok){ setTimeout(renderOrderQuiz, 800); }
           }
         });
-      });
+      }
     }
     renderOrderQuiz();
 
     // How to argue: what’s missing?
     const argueFeedback = document.getElementById('argueFeedback');
-    document.querySelectorAll('#argue .quiz-btn').forEach(btn=>{
+    for (const btn of document.querySelectorAll('#argue .quiz-btn')) {
       btn.addEventListener('click', ()=>{
         argueFeedback.textContent = 'Warranting. Give the reason/mechanism that makes the claim true.';
       });
-    });
+    }
 
     // Roles: Copy all outlines
     const rolesFeedback = document.getElementById('rolesFeedback');
@@ -785,35 +791,35 @@
       'poo-mo-new': ['Invalid', 'POOs target rebuttals/timing issues; MO is a constructive  -  not a POO.'],
       'poo-pmr-clarify': ['Invalid', 'Clarifying an existing mechanism isn’t new; usually not POOable.']
     };
-    document.querySelectorAll('#rebuttals .quiz-btn[data-q^="poo-"]').forEach(btn=>{
+    for (const btn of document.querySelectorAll('#rebuttals .quiz-btn[data-q^="poo-"]')) {
       btn.addEventListener('click', ()=>{
         const [verdict, why] = pooAnswers[btn.dataset.q] || ['',''];
         pooFeedback.textContent = `${verdict}: ${why}`;
       });
-    });
+    }
 
     // HOW TO WIN: A/B weighing
     const winFeedback = document.getElementById('winFeedback');
-    document.querySelectorAll('#win .quiz-btn').forEach(btn=>{
+    for (const btn of document.querySelectorAll('#win .quiz-btn')) {
       btn.addEventListener('click', ()=> winFeedback.textContent = 'B wins: it’s explicit weighing (comparative + axis).');
-    });
+    }
 
     // Flowing: spot the drop (tap option)
     const flowFeedback = document.getElementById('flowFeedback');
-    document.querySelectorAll('#flowing .quiz-btn[data-q="drop"]').forEach(btn=>{
+    for (const btn of document.querySelectorAll('#flowing .quiz-btn[data-q="drop"]')) {
       btn.addEventListener('click', ()=>{
         const guess = btn.dataset.guess;
         flowFeedback.textContent = (guess==='g2')
           ? 'Correct: G2 was dropped  -  extend and weigh it to a voter.'
           : 'Not quite  -  the drop was G2. Say it clearly and weigh it.';
       });
-    });
+    }
 
     // POIs quick question
     const poiFeedback = document.getElementById('poiFeedback');
-    document.querySelectorAll('#pois .quiz-btn').forEach(btn=>{
+    for (const btn of document.querySelectorAll('#pois .quiz-btn')) {
       btn.addEventListener('click', ()=> poiFeedback.textContent = 'Correct: rebuttals do not take POIs.');
-    });
+    }
   </script>
 </body>
 </html>

--- a/calendar.html
+++ b/calendar.html
@@ -196,28 +196,32 @@
     closeBtn.addEventListener('click', closeDrawer);
     scrim.addEventListener('click', closeDrawer);
 
-    document.querySelectorAll('.drawer-toggle').forEach(btn=>{
+    for (const btn of document.querySelectorAll('.drawer-toggle')) {
       btn.addEventListener('click',()=>{
         const ex = btn.getAttribute('aria-expanded')==='true';
         btn.setAttribute('aria-expanded', String(!ex));
         btn.nextElementSibling.classList.toggle('open');
       });
-    });
+    }
 
-    document.querySelectorAll('.has-submenu').forEach(item=>{
+    for (const item of document.querySelectorAll('.has-submenu')) {
       const link=item.querySelector('.top-link');
       item.addEventListener('mouseenter',()=>link.setAttribute('aria-expanded','true'));
       item.addEventListener('mouseleave',()=>link.setAttribute('aria-expanded','false'));
       link.addEventListener('focus',()=>link.setAttribute('aria-expanded','true'));
       const sm=item.querySelector('.submenu');
-      sm.addEventListener('keydown',e=>{ if(e.key==='Escape'){ link.focus(); link.setAttribute('aria-expanded','false'); } });
-    });
+      if(sm){
+        sm.addEventListener('keydown',e=>{ if(e.key==='Escape'){ link.focus(); link.setAttribute('aria-expanded','false'); } });
+      }
+    }
 
     // Reveal effect for cards
     const observer = new IntersectionObserver(entries => {
       entries.forEach(entry => entry.isIntersecting && entry.target.classList.add('reveal'));
     }, { threshold: 0.06 });
-    document.querySelectorAll('.glass-card').forEach(el => observer.observe(el));
+    for (const el of document.querySelectorAll('.glass-card')) {
+      observer.observe(el);
+    }
   </script>
 </body>
 </html>

--- a/contact.html
+++ b/contact.html
@@ -326,7 +326,9 @@
     const observer = new IntersectionObserver(entries => {
       entries.forEach(entry => entry.isIntersecting && entry.target.classList.add('reveal'));
     }, { threshold: 0.06 });
-    document.querySelectorAll('.glass-card').forEach(el => observer.observe(el));
+    for (const el of document.querySelectorAll('.glass-card')) {
+      observer.observe(el);
+    }
   </script>
 
   <!-- 2) Nav + drawer JS (copied pattern for consistent behavior) -->
@@ -366,25 +368,27 @@
     closeBtn.addEventListener('click', closeDrawer);
     scrim.addEventListener('click', closeDrawer);
 
-    document.querySelectorAll('.drawer-toggle').forEach(btn=>{
+    for (const btn of document.querySelectorAll('.drawer-toggle')) {
       btn.addEventListener('click',()=>{
         const ex = btn.getAttribute('aria-expanded')==='true';
         btn.setAttribute('aria-expanded', String(!ex));
         btn.nextElementSibling.classList.toggle('open');
       });
-    });
+    }
 
     window.addEventListener('keydown', e => { if(e.key==='Escape' && drawer.classList.contains('open')) closeDrawer(); });
 
     // Desktop submenu accessibility
-    document.querySelectorAll('.has-submenu').forEach(item=>{
+    for (const item of document.querySelectorAll('.has-submenu')) {
       const link = item.querySelector('.top-link');
       item.addEventListener('mouseenter',()=>link.setAttribute('aria-expanded','true'));
       item.addEventListener('mouseleave',()=>link.setAttribute('aria-expanded','false'));
       link.addEventListener('focus',()=>link.setAttribute('aria-expanded','true'));
       const sm = item.querySelector('.submenu');
-      sm?.addEventListener('keydown',e=>{ if(e.key==='Escape'){ link.focus(); link.setAttribute('aria-expanded','false'); } });
-    });
+      if(sm){
+        sm.addEventListener('keydown',e=>{ if(e.key==='Escape'){ link.focus(); link.setAttribute('aria-expanded','false'); } });
+      }
+    }
   </script>
 
 </body>

--- a/equity.html
+++ b/equity.html
@@ -337,7 +337,9 @@
     const observer = new IntersectionObserver(entries => {
       entries.forEach(entry => entry.isIntersecting && entry.target.classList.add('reveal'));
     }, { threshold: 0.06 });
-    document.querySelectorAll('.glass-card').forEach(el => observer.observe(el));
+    for (const el of document.querySelectorAll('.glass-card')) {
+      observer.observe(el);
+    }
 
     // Navbar -> set --nav-height
     const navbar = document.getElementById('siteNavbar');
@@ -361,23 +363,25 @@
     scrim.addEventListener('click', closeDrawer);
     window.addEventListener('keydown', e => { if(e.key==='Escape' && drawer.classList.contains('open')) closeDrawer(); });
 
-    document.querySelectorAll('.drawer-toggle').forEach(btn=>{
+    for (const btn of document.querySelectorAll('.drawer-toggle')) {
       btn.addEventListener('click',()=>{
         const ex = btn.getAttribute('aria-expanded')==='true';
         btn.setAttribute('aria-expanded', String(!ex));
         btn.nextElementSibling.classList.toggle('open');
       });
-    });
+    }
 
     // Desktop submenu a11y
-    document.querySelectorAll('.has-submenu').forEach(item=>{
+    for (const item of document.querySelectorAll('.has-submenu')) {
       const link=item.querySelector('.top-link');
       item.addEventListener('mouseenter',()=>link.setAttribute('aria-expanded','true'));
       item.addEventListener('mouseleave',()=>link.setAttribute('aria-expanded','false'));
       link.addEventListener('focus',()=>link.setAttribute('aria-expanded','true'));
       const sm=item.querySelector('.submenu');
-      sm?.addEventListener('keydown',e=>{ if(e.key==='Escape'){ link.focus(); link.setAttribute('aria-expanded','false'); } });
-    });
+      if(sm){
+        sm.addEventListener('keydown',e=>{ if(e.key==='Escape'){ link.focus(); link.setAttribute('aria-expanded','false'); } });
+      }
+    }
 
     // Contents drawer
     const tocDrawer = document.getElementById('tocDrawer');
@@ -403,7 +407,7 @@
     const tocLinks = [...document.querySelectorAll('.toc-list a')];
     window.addEventListener('scroll', () => {
       const y = window.scrollY + 120;
-      let current = sections[0]?.id;
+      let current = sections.length > 0 ? sections[0].id : undefined;
       for (const s of sections) { if (s.offsetTop <= y) current = s.id; }
       tocLinks.forEach(a => a.classList.toggle('active', a.getAttribute('href') === '#' + current));
     }, { passive: true });

--- a/index.html
+++ b/index.html
@@ -530,7 +530,9 @@
     const observer = new IntersectionObserver(entries => {
       entries.forEach(entry => entry.isIntersecting && entry.target.classList.add('reveal'));
     }, { threshold: 0.06 });
-    document.querySelectorAll('.glass-card, .section-wrap, .tile, .tiles-duo .path-card, .featured-wrap').forEach(el => observer.observe(el));
+    for (const el of document.querySelectorAll('.glass-card, .section-wrap, .tile, .tiles-duo .path-card, .featured-wrap')) {
+      observer.observe(el);
+    }
   </script>
 
   <!-- Nav + drawer JS + navbar measure -->
@@ -557,22 +559,24 @@
     scrim.addEventListener('click', closeDrawer);
     window.addEventListener('keydown', e => { if(e.key==='Escape' && drawer.classList.contains('open')) closeDrawer(); });
 
-    document.querySelectorAll('.drawer-toggle').forEach(btn=>{
+    for (const btn of document.querySelectorAll('.drawer-toggle')) {
       btn.addEventListener('click',()=>{
         const ex = btn.getAttribute('aria-expanded')==='true';
         btn.setAttribute('aria-expanded', String(!ex));
         btn.nextElementSibling.classList.toggle('open');
       });
-    });
+    }
 
-    document.querySelectorAll('.has-submenu').forEach(item=>{
+    for (const item of document.querySelectorAll('.has-submenu')) {
       const link=item.querySelector('.top-link');
       item.addEventListener('mouseenter',()=>link.setAttribute('aria-expanded','true'));
       item.addEventListener('mouseleave',()=>link.setAttribute('aria-expanded','false'));
       link.addEventListener('focus',()=>link.setAttribute('aria-expanded','true'));
       const sm=item.querySelector('.submenu');
-      sm.addEventListener('keydown',e=>{ if(e.key==='Escape'){ link.focus(); link.setAttribute('aria-expanded','false'); } });
-    });
+      if(sm){
+        sm.addEventListener('keydown',e=>{ if(e.key==='Escape'){ link.focus(); link.setAttribute('aria-expanded','false'); } });
+      }
+    }
   </script>
 
   <!-- New York Time countdown -->

--- a/join.html
+++ b/join.html
@@ -520,7 +520,9 @@
     const observer = new IntersectionObserver(entries => {
       entries.forEach(entry => entry.isIntersecting && entry.target.classList.add('reveal'));
     }, { threshold: 0.06 });
-    document.querySelectorAll('.glass-card').forEach(el => observer.observe(el));
+    for (const el of document.querySelectorAll('.glass-card')) {
+      observer.observe(el);
+    }
 
     // Keep --nav-height accurate (for countdown)
     const navbar = document.getElementById('siteNavbar');
@@ -553,23 +555,25 @@
     closeBtn.addEventListener('click', closeDrawer);
     scrim.addEventListener('click', closeDrawer);
     window.addEventListener('keydown', e => { if(e.key==='Escape' && drawer.classList.contains('open')) closeDrawer(); });
-    document.querySelectorAll('.drawer-toggle').forEach(btn=>{
+    for (const btn of document.querySelectorAll('.drawer-toggle')) {
       btn.addEventListener('click',()=>{
         const ex = btn.getAttribute('aria-expanded')==='true';
         btn.setAttribute('aria-expanded', String(!ex));
         btn.nextElementSibling.classList.toggle('open');
       });
-    });
+    }
 
     // Desktop submenu a11y
-    document.querySelectorAll('.has-submenu').forEach(item=>{
+    for (const item of document.querySelectorAll('.has-submenu')) {
       const link=item.querySelector('.top-link');
       item.addEventListener('mouseenter',()=>link.setAttribute('aria-expanded','true'));
       item.addEventListener('mouseleave',()=>link.setAttribute('aria-expanded','false'));
       link.addEventListener('focus',()=>link.setAttribute('aria-expanded','true'));
       const sm=item.querySelector('.submenu');
-      sm?.addEventListener('keydown',e=>{ if(e.key==='Escape'){ link.focus(); link.setAttribute('aria-expanded','false'); } });
-    });
+      if(sm){
+        sm.addEventListener('keydown',e=>{ if(e.key==='Escape'){ link.focus(); link.setAttribute('aria-expanded','false'); } });
+      }
+    }
 
     // ---------- New York Time countdown ----------
     function getNowPartsInTZ(timeZone){
@@ -639,7 +643,7 @@
         intro.classList.add('show');
         document.body.style.overflow = 'hidden';
         // focus join button for a11y
-        setTimeout(()=> joinBtn?.focus(), 50);
+        setTimeout(()=>{ if(joinBtn) joinBtn.focus(); }, 50);
       }
       function closeIntro(){
         intro.classList.add('fading');
@@ -661,7 +665,9 @@
         function dismiss(){
           clearTimeout(t); closeIntro();
         }
-        joinBtn?.addEventListener('click', dismiss);
+        if(joinBtn){
+          joinBtn.addEventListener('click', dismiss);
+        }
         intro.addEventListener('click', e=>{
           // allow clicking the dim background to dismiss; ignore clicks inside the panel
           if(e.target === intro) dismiss();

--- a/judging.html
+++ b/judging.html
@@ -660,7 +660,9 @@
     const observer = new IntersectionObserver(entries => {
       entries.forEach(e => e.isIntersecting && e.target.classList.add('reveal'));
     }, { threshold: 0.06 });
-    document.querySelectorAll('.glass-card').forEach(el => observer.observe(el));
+    for (const el of document.querySelectorAll('.glass-card')) {
+      observer.observe(el);
+    }
 
     const navbar = document.getElementById('siteNavbar');
     function setNavHeightVar(){
@@ -682,21 +684,23 @@
     scrim.addEventListener('click', closeDrawer);
     addEventListener('keydown', e => { if(e.key==='Escape' && drawer.classList.contains('open')) closeDrawer(); });
 
-    document.querySelectorAll('.drawer-toggle').forEach(btn=>{
+    for (const btn of document.querySelectorAll('.drawer-toggle')) {
       btn.addEventListener('click',()=>{
         const ex = btn.getAttribute('aria-expanded')==='true';
         btn.setAttribute('aria-expanded', String(!ex));
         btn.nextElementSibling.classList.toggle('open');
       });
-    });
-    document.querySelectorAll('.has-submenu').forEach(item=>{
+    }
+    for (const item of document.querySelectorAll('.has-submenu')) {
       const link=item.querySelector('.top-link');
       item.addEventListener('mouseenter',()=>link.setAttribute('aria-expanded','true'));
       item.addEventListener('mouseleave',()=>link.setAttribute('aria-expanded','false'));
       link.addEventListener('focus',()=>link.setAttribute('aria-expanded','true'));
       const sm=item.querySelector('.submenu');
-      sm?.addEventListener('keydown',e=>{ if(e.key==='Escape'){ link.focus(); link.setAttribute('aria-expanded','false'); } });
-    });
+      if(sm){
+        sm.addEventListener('keydown',e=>{ if(e.key==='Escape'){ link.focus(); link.setAttribute('aria-expanded','false'); } });
+      }
+    }
 
     /* ==========================================================
       CONTENTS DRAWER: desktop default open; closable/reopenable;
@@ -730,7 +734,7 @@
     const tocLinks = [...document.querySelectorAll('.toc-list a')];
     addEventListener('scroll', () => {
       const y = scrollY + 120;
-      let current = sections[0]?.id;
+      let current = sections.length > 0 ? sections[0].id : undefined;
       for (const s of sections) { if (s.offsetTop <= y) current = s.id; }
       tocLinks.forEach(a => a.classList.toggle('active', a.getAttribute('href') === '#' + current));
     }, { passive: true });
@@ -825,10 +829,10 @@ ${fbO || ' - '}
           <div class="answer"><b>${s.verdict.toUpperCase()}</b>  -  ${s.a}</div>
         </div>
       `).join('');
-      quizWrap.querySelectorAll('.quiz-chip').forEach(ch=>{
+      for (const ch of quizWrap.querySelectorAll('.quiz-chip')) {
         ch.addEventListener('click', ()=> toggleChip(ch));
         ch.addEventListener('keydown', e=>{ if(e.key==='Enter' || e.key===' '){ e.preventDefault(); toggleChip(ch); } });
-      });
+      }
     }
     function toggleChip(ch){
       const open = ch.classList.contains('open');

--- a/leadership.html
+++ b/leadership.html
@@ -501,7 +501,9 @@
     const io = new IntersectionObserver((entries)=> {
       entries.forEach(e => { if(e.isIntersecting){ e.target.classList.add('reveal'); io.unobserve(e.target); } });
     }, { threshold: .08 });
-    document.querySelectorAll('.fade-in').forEach(el => io.observe(el));
+    for (const el of document.querySelectorAll('.fade-in')) {
+      io.observe(el);
+    }
 
     // ===== navbar / drawer =====
     const navbar = document.getElementById('siteNavbar');
@@ -523,21 +525,23 @@
     drawerClose.addEventListener('click', closeDrawer);
     scrim.addEventListener('click', closeDrawer);
     window.addEventListener('keydown', e => { if(e.key==='Escape' && drawer.classList.contains('open')) closeDrawer(); });
-    document.querySelectorAll('.drawer-toggle').forEach(btn=>{
+    for (const btn of document.querySelectorAll('.drawer-toggle')) {
       btn.addEventListener('click',()=>{
         const ex = btn.getAttribute('aria-expanded')==='true';
         btn.setAttribute('aria-expanded', String(!ex));
         btn.nextElementSibling.classList.toggle('open');
       });
-    });
-    document.querySelectorAll('.has-submenu').forEach(item=>{
+    }
+    for (const item of document.querySelectorAll('.has-submenu')) {
       const link=item.querySelector('.top-link');
       item.addEventListener('mouseenter',()=>link.setAttribute('aria-expanded','true'));
       item.addEventListener('mouseleave',()=>link.setAttribute('aria-expanded','false'));
       link.addEventListener('focus',()=>link.setAttribute('aria-expanded','true'));
       const sm=item.querySelector('.submenu');
-      sm?.addEventListener('keydown',e=>{ if(e.key==='Escape'){ link.focus(); link.setAttribute('aria-expanded','false'); } });
-    });
+      if(sm){
+        sm.addEventListener('keydown',e=>{ if(e.key==='Escape'){ link.focus(); link.setAttribute('aria-expanded','false'); } });
+      }
+    }
 
     // ===== modal logic =====
     const modal = document.getElementById('leaderModal');
@@ -584,7 +588,7 @@
     }
 
     // open handlers
-    document.querySelectorAll('.leader-card').forEach(card=>{
+    for (const card of document.querySelectorAll('.leader-card')) {
       card.addEventListener('click', ()=>{
         const data = {
           name: card.dataset.name,
@@ -596,7 +600,7 @@
         openModal(data);
       });
       // Enter/Space already work on button; no extra key handler needed
-    });
+    }
 
     // close handlers
     modal.addEventListener('click', (e)=>{

--- a/members.html
+++ b/members.html
@@ -524,7 +524,9 @@
     const observer = new IntersectionObserver(entries => {
       entries.forEach(entry => entry.isIntersecting && entry.target.classList.add('reveal'));
     }, { threshold: 0.06 });
-    document.querySelectorAll('.dash-card, .target-card').forEach(el => observer.observe(el));
+    for (const el of document.querySelectorAll('.dash-card, .target-card')) {
+      observer.observe(el);
+    }
   </script>
 
   <script>
@@ -566,14 +568,16 @@
     window.addEventListener('keydown', e => { if(e.key==='Escape' && drawer.classList.contains('open')) closeDrawer(); });
 
     // Desktop submenu accessibility affordances
-    document.querySelectorAll('.has-submenu').forEach(item=>{
+    for (const item of document.querySelectorAll('.has-submenu')) {
       const link = item.querySelector('.top-link');
       item.addEventListener('mouseenter',()=>link.setAttribute('aria-expanded','true'));
       item.addEventListener('mouseleave',()=>link.setAttribute('aria-expanded','false'));
       link.addEventListener('focus',()=>link.setAttribute('aria-expanded','true'));
       const sm = item.querySelector('.submenu');
-      sm?.addEventListener('keydown',e=>{ if(e.key==='Escape'){ link.focus(); link.setAttribute('aria-expanded','false'); } });
-    });
+      if(sm){
+        sm.addEventListener('keydown',e=>{ if(e.key==='Escape'){ link.focus(); link.setAttribute('aria-expanded','false'); } });
+      }
+    }
   </script>
 </body>
 </html>

--- a/practicetools.html
+++ b/practicetools.html
@@ -706,7 +706,9 @@ Reason #2  -  warrants → impact"></textarea>
     const observer = new IntersectionObserver(entries => {
       entries.forEach(e => e.isIntersecting && e.target.classList.add('reveal'));
     }, { threshold: 0.06 });
-    document.querySelectorAll('.glass-card').forEach(el => observer.observe(el));
+    for (const el of document.querySelectorAll('.glass-card')) {
+      observer.observe(el);
+    }
 
     /* --- Navbar sizing var --- */
     const navbar = document.getElementById('siteNavbar');
@@ -730,21 +732,23 @@ Reason #2  -  warrants → impact"></textarea>
     scrim.addEventListener('click', closeDrawer);
     addEventListener('keydown', e => { if(e.key==='Escape' && drawer.classList.contains('open')) closeDrawer(); });
 
-    document.querySelectorAll('.drawer-toggle').forEach(btn=>{
+    for (const btn of document.querySelectorAll('.drawer-toggle')) {
       btn.addEventListener('click',()=>{
         const ex = btn.getAttribute('aria-expanded')==='true';
         btn.setAttribute('aria-expanded', String(!ex));
         btn.nextElementSibling.classList.toggle('open');
       });
-    });
-    document.querySelectorAll('.has-submenu').forEach(item=>{
+    }
+    for (const item of document.querySelectorAll('.has-submenu')) {
       const link=item.querySelector('.top-link');
       item.addEventListener('mouseenter',()=>link.setAttribute('aria-expanded','true'));
       item.addEventListener('mouseleave',()=>link.setAttribute('aria-expanded','false'));
       link.addEventListener('focus',()=>link.setAttribute('aria-expanded','true'));
       const sm=item.querySelector('.submenu');
-      sm?.addEventListener('keydown',e=>{ if(e.key==='Escape'){ link.focus(); link.setAttribute('aria-expanded','false'); } });
-    });
+      if(sm){
+        sm.addEventListener('keydown',e=>{ if(e.key==='Escape'){ link.focus(); link.setAttribute('aria-expanded','false'); } });
+      }
+    }
 
     /* --- Contents drawer: desktop defaults open, but can be X-closed & re-opened --- */
     const tocDrawer = document.getElementById('tocDrawer');
@@ -782,7 +786,7 @@ Reason #2  -  warrants → impact"></textarea>
     const tocLinks = [...document.querySelectorAll('.toc-list a')];
     addEventListener('scroll', () => {
       const y = scrollY + 120;
-      let current = sections[0]?.id;
+      let current = sections.length > 0 ? sections[0].id : undefined;
       for (const s of sections) { if (s.offsetTop <= y) current = s.id; }
       tocLinks.forEach(a => a.classList.toggle('active', a.getAttribute('href') === '#' + current));
     }, { passive: true });
@@ -842,7 +846,9 @@ Reason #2  -  warrants → impact"></textarea>
     }
     function stopTimer(){ clearInterval(ticking); ticking=null; syncFloat(); }
     function resetTimer(){ remain = totalSec; updateDial(); }
-    document.querySelectorAll('.timer-presets .btn').forEach(b => b.addEventListener('click', ()=> setPreset(+b.dataset.sec)));
+    for (const b of document.querySelectorAll('.timer-presets .btn')) {
+      b.addEventListener('click', ()=> setPreset(+b.dataset.sec));
+    }
     document.getElementById('startTimer').addEventListener('click', startTimer);
     document.getElementById('pauseTimer').addEventListener('click', stopTimer);
     document.getElementById('resetTimer').addEventListener('click', ()=>{ resetTimer(); setFloatVisible(false); });
@@ -883,7 +889,7 @@ Reason #2  -  warrants → impact"></textarea>
     function isTyping(){
       const el = document.activeElement;
       if(!el) return false;
-      const tag = el.tagName?.toLowerCase();
+      const tag = el.tagName ? el.tagName.toLowerCase() : undefined;
       return tag==='input' || tag==='textarea' || el.isContentEditable;
     }
     addEventListener('keydown', e=>{
@@ -932,7 +938,7 @@ Reason #2  -  warrants → impact"></textarea>
 
     // POCs quick add
     const pocLog = document.getElementById('pocLog');
-    document.querySelectorAll('button[data-poc]').forEach(btn=>{
+    for (const btn of document.querySelectorAll('button[data-poc]')) {
       btn.addEventListener('click', ()=>{
         const map = {
           defs: 'POC: Could you clarify how you’re defining [term]?  -  A:',
@@ -945,7 +951,7 @@ Reason #2  -  warrants → impact"></textarea>
         pocLog.focus();
         pocLog.setSelectionRange(pocLog.value.length, pocLog.value.length);
       });
-    });
+    }
     document.getElementById('copyPOCs').addEventListener('click', async ()=>{
       try{ await navigator.clipboard.writeText(pocLog.value); alert('POCs copied.'); } catch{ alert('Copy failed.'); }
     });

--- a/resources.html
+++ b/resources.html
@@ -572,7 +572,9 @@
     const observer = new IntersectionObserver(entries => {
       entries.forEach(e => e.isIntersecting && e.target.classList.add('reveal'));
     }, { threshold: 0.06 });
-    document.querySelectorAll('.glass-card').forEach(el => observer.observe(el));
+    for (const el of document.querySelectorAll('.glass-card')) {
+      observer.observe(el);
+    }
 
     const navbar = document.getElementById('siteNavbar');
     function setNavHeightVar(){
@@ -595,21 +597,23 @@
     scrim.addEventListener('click', closeDrawer);
     addEventListener('keydown', e => { if(e.key==='Escape' && drawer.classList.contains('open')) closeDrawer(); });
 
-    document.querySelectorAll('.drawer-toggle').forEach(btn=>{
+    for (const btn of document.querySelectorAll('.drawer-toggle')) {
       btn.addEventListener('click',()=>{
         const ex = btn.getAttribute('aria-expanded')==='true';
         btn.setAttribute('aria-expanded', String(!ex));
         btn.nextElementSibling.classList.toggle('open');
       });
-    });
-    document.querySelectorAll('.has-submenu').forEach(item=>{
+    }
+    for (const item of document.querySelectorAll('.has-submenu')) {
       const link=item.querySelector('.top-link');
       item.addEventListener('mouseenter',()=>link.setAttribute('aria-expanded','true'));
       item.addEventListener('mouseleave',()=>link.setAttribute('aria-expanded','false'));
       link.addEventListener('focus',()=>link.setAttribute('aria-expanded','true'));
       const sm=item.querySelector('.submenu');
-      sm?.addEventListener('keydown',e=>{ if(e.key==='Escape'){ link.focus(); link.setAttribute('aria-expanded','false'); } });
-    });
+      if(sm){
+        sm.addEventListener('keydown',e=>{ if(e.key==='Escape'){ link.focus(); link.setAttribute('aria-expanded','false'); } });
+      }
+    }
 
     /* --- Contents drawer: desktop defaults open, can be X-closed & re-opened; no memory across refresh --- */
     const tocDrawer = document.getElementById('tocDrawer');
@@ -640,7 +644,7 @@
     const tocLinks = [...document.querySelectorAll('.toc-list a')];
     addEventListener('scroll', () => {
       const y = scrollY + 120;
-      let current = sections[0]?.id;
+      let current = sections.length > 0 ? sections[0].id : undefined;
       for (const s of sections) { if (s.offsetTop <= y) current = s.id; }
       tocLinks.forEach(a => a.classList.toggle('active', a.getAttribute('href') === '#' + current));
     }, { passive: true });

--- a/tournaments.html
+++ b/tournaments.html
@@ -567,7 +567,9 @@
     const observer = new IntersectionObserver(entries => {
       entries.forEach(entry => entry.isIntersecting && entry.target.classList.add('reveal'));
     }, { threshold: 0.06 });
-    document.querySelectorAll('.glass-card').forEach(el => observer.observe(el));
+    for (const el of document.querySelectorAll('.glass-card')) {
+      observer.observe(el);
+    }
 
     // Keep --nav-height accurate
     const navbar = document.getElementById('siteNavbar');
@@ -590,25 +592,27 @@
     closeBtn.addEventListener('click', closeDrawer);
     scrim.addEventListener('click', closeDrawer);
 
-    document.querySelectorAll('.drawer-toggle').forEach(btn=>{
+    for (const btn of document.querySelectorAll('.drawer-toggle')) {
       btn.addEventListener('click',()=>{
         const ex = btn.getAttribute('aria-expanded')==='true';
         btn.setAttribute('aria-expanded', String(!ex));
         btn.nextElementSibling.classList.toggle('open');
       });
-    });
+    }
 
     window.addEventListener('keydown', e => { if(e.key==='Escape' && drawer.classList.contains('open')) closeDrawer(); });
 
     // Desktop submenu a11y
-    document.querySelectorAll('.has-submenu').forEach(item=>{
+    for (const item of document.querySelectorAll('.has-submenu')) {
       const link=item.querySelector('.top-link');
       item.addEventListener('mouseenter',()=>link.setAttribute('aria-expanded','true'));
       item.addEventListener('mouseleave',()=>link.setAttribute('aria-expanded','false'));
       link.addEventListener('focus',()=>link.setAttribute('aria-expanded','true'));
       const sm=item.querySelector('.submenu');
-      sm?.addEventListener('keydown',e=>{ if(e.key==='Escape'){ link.focus(); link.setAttribute('aria-expanded','false'); } });
-    });
+      if(sm){
+        sm.addEventListener('keydown',e=>{ if(e.key==='Escape'){ link.focus(); link.setAttribute('aria-expanded','false'); } });
+      }
+    }
 
     // ----- Contents drawer (IDENTICAL logic to About) -----
     const tocDrawer = document.getElementById('tocDrawer');
@@ -635,16 +639,16 @@
     const tocLinks = [...document.querySelectorAll('.toc-list a')];
     window.addEventListener('scroll', () => {
       const y = window.scrollY + 120;
-      let current = sections[0]?.id;
+      let current = sections.length > 0 ? sections[0].id : undefined;
       for (const s of sections) { if (s.offsetTop <= y) current = s.id; }
       tocLinks.forEach(a => a.classList.toggle('active', a.getAttribute('href') === '#' + current));
     }, { passive: true });
   </script>
   <script>
-    document.querySelectorAll('.badge-need').forEach(b => {
+    for (const b of document.querySelectorAll('.badge-need')) {
       const raw = (b.getAttribute('data-judges-needed') || '').toLowerCase().trim();
       const countEl = b.querySelector('.need-count');
-      if (!countEl) return;
+      if (!countEl) continue;
       if (!raw || raw === 'tbd') {
         countEl.textContent = 'TBD';
         b.classList.remove('ok'); b.classList.add('tbd');
@@ -659,7 +663,7 @@
           b.classList.remove('ok'); b.classList.add('tbd');
         }
       }
-    });
+    }
   </script>
 </body>
 </html>

--- a/why-pdu.html
+++ b/why-pdu.html
@@ -457,7 +457,9 @@
     const observer = new IntersectionObserver(entries => {
       entries.forEach(entry => entry.isIntersecting && entry.target.classList.add('reveal'));
     }, { threshold: 0.06 });
-    document.querySelectorAll('.glass-card').forEach(el => observer.observe(el));
+    for (const el of document.querySelectorAll('.glass-card')) {
+      observer.observe(el);
+    }
 
     // Measure navbar for drawer offset
     const navbar = document.getElementById('siteNavbar');
@@ -480,23 +482,25 @@
     closeBtn.addEventListener('click', closeDrawer);
     scrim.addEventListener('click', closeDrawer);
     window.addEventListener('keydown', e => { if(e.key==='Escape' && drawer.classList.contains('open')) closeDrawer(); });
-    document.querySelectorAll('.drawer-toggle').forEach(btn=>{
+    for (const btn of document.querySelectorAll('.drawer-toggle')) {
       btn.addEventListener('click',()=>{
         const ex = btn.getAttribute('aria-expanded')==='true';
         btn.setAttribute('aria-expanded', String(!ex));
         btn.nextElementSibling.classList.toggle('open');
       });
-    });
+    }
 
     // Desktop submenu a11y
-    document.querySelectorAll('.has-submenu').forEach(item=>{
+    for (const item of document.querySelectorAll('.has-submenu')) {
       const link=item.querySelector('.top-link');
       item.addEventListener('mouseenter',()=>link.setAttribute('aria-expanded','true'));
       item.addEventListener('mouseleave',()=>link.setAttribute('aria-expanded','false'));
       link.addEventListener('focus',()=>link.setAttribute('aria-expanded','true'));
       const sm=item.querySelector('.submenu');
-      sm?.addEventListener('keydown',e=>{ if(e.key==='Escape'){ link.focus(); link.setAttribute('aria-expanded','false'); } });
-    });
+      if(sm){
+        sm.addEventListener('keydown',e=>{ if(e.key==='Escape'){ link.focus(); link.setAttribute('aria-expanded','false'); } });
+      }
+    }
 
     // Contents drawer
     const tocDrawer = document.getElementById('tocDrawer');
@@ -522,7 +526,7 @@
     const tocLinks = [...document.querySelectorAll('.toc-list a')];
     window.addEventListener('scroll', () => {
       const y = window.scrollY + 120;
-      let current = sections[0]?.id;
+      let current = sections.length > 0 ? sections[0].id : undefined;
       for (const s of sections) { if (s.offsetTop <= y) current = s.id; }
       tocLinks.forEach(a => a.classList.toggle('active', a.getAttribute('href') === '#' + current));
     }, { passive: true });


### PR DESCRIPTION
## Summary
- replace usages of `NodeList.forEach` in navigation scripts with for-of loops so mobile drawer and submenu logic work on older Safari builds
- remove optional chaining and guard submenu listeners so the shared code paths stay compatible with pre-13.1 Safari
- update shared form utilities to use the same for-of pattern

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68c8c8cd8b5883228c1057d438cb5e68