### PR TITLE
Add Hopkins sign-up reminder to members announcements

### DIFF
--- a/members.html
+++ b/members.html
@@ -409,6 +409,21 @@
             <p class="about-preview">Latest updates from the board. Action items at a glance.</p>
 
             <div class="announce-grid" style="margin-top:.7rem;">
+              <div class="announce">
+                <article class="target-card">
+                  <span class="pill open">Travel sign-up</span>
+                  <h4>Johns Hopkins Novice: Spots still open</h4>
+                  <p class="about-preview">Sign-ups are still open—we have competitor and judge slots for the Oct 3–4 Johns Hopkins Novice (APDA) weekend. If you want to travel, add your name so we can finalize the roster.</p>
+                  <ul class="about-preview">
+                    <li><strong>Who:</strong> First-year debaters and anyone willing to judge—no prior travel required.</li>
+                    <li><strong>Action:</strong> Submit the travel form ASAP so we can lock travel pairings and logistics.</li>
+                  </ul>
+                  <div class="cta-row">
+                    <a class="link-chip" href="https://forms.gle/sEoHBcDgiaGoPA5T8" target="_blank" rel="noopener">Sign up →</a>
+                    <a class="link-chip" href="tournaments.html#featured">Event details →</a>
+                  </div>
+                </article>
+              </div>
               <div class="announce wide">
                 <article class="target-card">
                   <span class="pill confirmed">Sep 10</span>


### PR DESCRIPTION
## Summary
- add a new announcement card to the members dashboard
- highlight that Johns Hopkins Novice sign-ups remain open and link to the form

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d2002a461083228153c03999593892