### PR TITLE
Make home photo rail scrollable on desktop

### DIFF
--- a/index.html
+++ b/index.html
@@ -107,8 +107,7 @@
     }
     .rail-item img{ width:100%; height:100%; object-fit:cover; display:block; }
     @media (min-width: 1100px){
-      .rail-wrap{ overflow-x:visible; }
-      .rail-item{ flex:1; }
+      .rail-item{ flex:0 0 30%; }
     }
 
     /* Lightbox */


### PR DESCRIPTION
## Summary
- keep the Why PDU photo rail scrollable on wide screens by removing the overflow override
- ensure desktop items retain a consistent card width instead of stretching to fill the row

## Testing
- No automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d5798d873c832295a012dcb697becf