### PR TITLE
Update Johns Hopkins Novice details after roster confirmation

### DIFF
--- a/index.html
+++ b/index.html
@@ -456,14 +456,13 @@
             <span class="chip">Baltimore, MD</span>
             <span class="chip">Motion Tournament</span>
           </div>
-          <p class="about-preview" style="margin:.25rem 0 0;">APDA novice weekend stop hosted by Johns Hopkins UDC on the Homewood campus. Sign-ups are <strong>OPEN</strong>: <a href="https://forms.gle/sEoHBcDgiaGoPA5T8" target="_blank" rel="noopener">submit the form →</a>.</p>
+          <p class="about-preview" style="margin:.25rem 0 0;">APDA novice weekend stop hosted by Johns Hopkins UDC on the Homewood campus. The travel roster is confirmed; logistics updates will be shared with the team.</p>
           <div class="cta-row" style="margin-top:.6rem;">
             <a class="link-chip" href="tournaments.html">Event details →</a>
-            <a class="link-chip" href="https://forms.gle/sEoHBcDgiaGoPA5T8" target="_blank" rel="noopener">Sign up →</a>
           </div>
         </div>
         <div class="featured-side">
-          <span class="pill open">Sign-ups open</span>
+          <span class="pill confirmed">Roster Confirmed</span>
         </div>
       </div>
     </section>
@@ -475,13 +474,12 @@
         <article class="event-card">
           <div class="event-head">
             <h4>Johns Hopkins Novice (APDA)</h4>
-            <span class="pill open">Sign-ups open</span>
+            <span class="pill confirmed">Roster Confirmed</span>
           </div>
           <p class="event-meta">Oct 3–4 · Baltimore, MD</p>
-          <p class="event-note">Motion tournament during APDA novice weekend hosted by Johns Hopkins UDC. Sign-ups are <strong>OPEN</strong>: <a href="https://forms.gle/sEoHBcDgiaGoPA5T8" target="_blank" rel="noopener">complete the form →</a>.</p>
+          <p class="event-note">Motion tournament during APDA novice weekend hosted by Johns Hopkins UDC. Roster confirmed; coordinators will send travel details directly.</p>
           <div class="cta-row" style="gap:.4rem;">
             <a class="link-chip" href="tournaments.html">Details →</a>
-            <a class="link-chip" href="https://forms.gle/sEoHBcDgiaGoPA5T8" target="_blank" rel="noopener">Sign up →</a>
           </div>
         </article>
 

--- a/join.html
+++ b/join.html
@@ -415,7 +415,7 @@
           <ul>
             <li>Kickoff lessons begin</li>
             <li>First scrim night</li>
-              <li>Travel: Prep for Johns Hopkins Novice (APDA) — APDA novice weekend motion tournament Oct 3–4 in Baltimore. <strong>Sign-ups are OPEN:</strong> <a href="https://forms.gle/sEoHBcDgiaGoPA5T8" target="_blank" rel="noopener">Submit the form →</a></li>
+              <li>Travel: Prep for Johns Hopkins Novice (APDA) — APDA novice weekend motion tournament Oct 3–4 in Baltimore. Roster confirmed; travel briefing during meetings.</li>
           </ul>
           <div class="cta-row"><a class="link-chip" href="calendar.html">Open calendar →</a></div>
         </div>
@@ -423,7 +423,7 @@
           <h4>October</h4>
           <ul>
             <li>Casebuilding workshop</li>
-              <li>Travel: Johns Hopkins Novice (APDA) — APDA novice weekend motion tournament Oct 3–4 in Baltimore; <strong>Sign-ups are OPEN</strong>: <a href="https://forms.gle/sEoHBcDgiaGoPA5T8" target="_blank" rel="noopener">Submit the form →</a>; Harvard (APDA Meeting, tentative); Brown (tentative)</li>
+              <li>Travel: Johns Hopkins Novice (APDA) — APDA novice weekend motion tournament Oct 3–4 in Baltimore (roster confirmed); Harvard (APDA Meeting, tentative); Brown (tentative)</li>
             <li>Novice spotlight night</li>
           </ul>
           <div class="cta-row"><a class="link-chip" href="calendar.html">Open calendar →</a></div>

--- a/members.html
+++ b/members.html
@@ -288,19 +288,18 @@
           <div class="dash-card accent-warn span-5">
             <h3 class="about-header" style="margin-top:.1rem;">Upcoming Travel  -  Overview</h3>
             <p class="about-preview" style="margin-bottom:.75rem;">
-              First stop: Johns Hopkins Novice (APDA) — APDA novice weekend motion tournament Oct 3–4 in Baltimore. Sign-ups are <strong>OPEN</strong>: <a href="https://forms.gle/sEoHBcDgiaGoPA5T8" target="_blank" rel="noopener">submit the form →</a>. Harvard and Brown follow later in the month.
+              First stop: Johns Hopkins Novice (APDA) — APDA novice weekend motion tournament Oct 3–4 in Baltimore. Roster is confirmed; Harvard and Brown follow later in the month.
             </p>
 
             <div class="targets-grid overview">
               <article class="target-card">
-                <span class="pill open">Sign-ups open</span>
+                <span class="pill confirmed">Roster Confirmed</span>
                 <div class="chip-row"><span class="chip">Oct 3–4</span><span class="chip">Johns Hopkins Novice (APDA)</span></div>
                 <h3>Johns Hopkins Novice (APDA)</h3>
-                <p class="about-preview" style="margin:.55rem 0 .65rem;">APDA novice weekend motion tournament on Johns Hopkins’ Homewood campus. Sign-ups are <strong>OPEN</strong>: <a href="https://forms.gle/sEoHBcDgiaGoPA5T8" target="_blank" rel="noopener">complete the form →</a>.</p>
+                <p class="about-preview" style="margin:.55rem 0 .65rem;">APDA novice weekend motion tournament on Johns Hopkins’ Homewood campus. Roster is confirmed; watch for travel logistics from the directors.</p>
                 <div class="cta-row">
                   <a class="link-chip" href="tournaments.html">Details →</a>
                   <a class="link-chip" href="calendar.html">Calendar →</a>
-                  <a class="link-chip" href="https://forms.gle/sEoHBcDgiaGoPA5T8" target="_blank" rel="noopener">Sign up →</a>
                 </div>
               </article>
 
@@ -411,15 +410,14 @@
             <div class="announce-grid" style="margin-top:.7rem;">
               <div class="announce">
                 <article class="target-card">
-                  <span class="pill open">Travel sign-up</span>
-                  <h4>Johns Hopkins Novice: Spots still open</h4>
-                  <p class="about-preview">Sign-ups are still open—we have competitor and judge slots for the Oct 3–4 Johns Hopkins Novice (APDA) weekend. If you want to travel, add your name so we can finalize the roster.</p>
+                  <span class="pill confirmed">Travel Update</span>
+                  <h4>Johns Hopkins Novice: Roster finalized</h4>
+                  <p class="about-preview">The roster is set for the Oct 3–4 Johns Hopkins Novice (APDA) weekend. Travel directors are distributing pairings, judging assignments, and logistics.</p>
                   <ul class="about-preview">
-                    <li><strong>Who:</strong> First-year debaters and anyone willing to judge—no prior travel required.</li>
-                    <li><strong>Action:</strong> Submit the travel form ASAP so we can lock travel pairings and logistics.</li>
+                    <li><strong>Who:</strong> Confirmed travelers and judges — check your email and Slack for itinerary details.</li>
+                    <li><strong>Action:</strong> Reach out to Travel if you have conflicts or need accessibility accommodations.</li>
                   </ul>
                   <div class="cta-row">
-                    <a class="link-chip" href="https://forms.gle/sEoHBcDgiaGoPA5T8" target="_blank" rel="noopener">Sign up →</a>
                     <a class="link-chip" href="tournaments.html#featured">Event details →</a>
                   </div>
                 </article>

--- a/tournaments.html
+++ b/tournaments.html
@@ -244,7 +244,7 @@
         <div class="feature-left">
           <div class="event-head">
             <h3>Johns Hopkins Novice (APDA)</h3>
-            <span class="pill open">Sign-ups open</span>
+            <span class="pill confirmed">Roster Confirmed</span>
           </div>
           <div class="event-badges">
             <span class="badge-need" data-judges-needed="3" title="Estimated judges needed">
@@ -260,7 +260,7 @@
           </div>
           <p class="muted">Part of APDA’s annual novice weekend and hosted by the Johns Hopkins Undergraduate Debate Council on the Homewood campus in Baltimore.</p>
           <ul class="section-list" style="margin-top:.6rem;">
-            <li><strong>Sign-ups:</strong> <strong>OPEN</strong> — <a href="https://forms.gle/sEoHBcDgiaGoPA5T8" target="_blank" rel="noopener">Submit the interest form →</a></li>
+            <li><strong>Roster:</strong> Confirmed — travel pairings and judge assignments are set.</li>
             <li><strong>Division:</strong> Novice-only field; APDA motion sets</li>
             <li><strong>Funding:</strong> PDU covers travel, registration, lodging.</li>
             <li><strong>Details:</strong> APDA’s Schedule page and the public 25–26 Scheduling Sheet already list the event; expect the full invite on the APDA Forum (login required).</li>
@@ -268,9 +268,8 @@
           <div class="cta-row" style="margin-top:.75rem;">
             <a class="link-chip" href="calendar.html">Add/See on Calendar →</a>
             <a class="link-chip" href="https://drive.google.com/drive/folders/1SIot57czQp_hxY6Bx38I_SN4deVhbvDo?usp=drive_link" target="_blank" rel="noopener">TID (Drive) →</a>
-            <a class="link-chip" href="https://forms.gle/sEoHBcDgiaGoPA5T8" target="_blank" rel="noopener">Sign up →</a>
           </div>
-          <p class="note">Sign-ups are OPEN: <a href="https://forms.gle/sEoHBcDgiaGoPA5T8" target="_blank" rel="noopener">complete the form</a> to tell us if you want to debate or judge.</p>
+          <p class="note">Roster confirmed — Travel Directors will share logistics and any waitlist updates directly.</p>
         </div>
 
         <aside class="feature-right">
@@ -293,7 +292,7 @@
         <article class="target-card" role="listitem">
           <div class="event-head">
             <h4>Johns Hopkins Novice (APDA)</h4>
-            <span class="pill open">Sign-ups open</span>
+            <span class="pill confirmed">Roster Confirmed</span>
           </div>
           <div class="event-badges">
             <span class="badge-need" data-judges-needed="3" title="Estimated judges needed">
@@ -307,11 +306,10 @@
             <span class="chip">Motion Tournament</span>
             <span class="chip">Oct 3–4</span>
           </div>
-          <p class="about-preview" style="margin:.25rem 0 .4rem;">Motion tournament hosted by Johns Hopkins UDC on the Homewood campus. Sign-ups are <strong>OPEN</strong>: <a href="https://forms.gle/sEoHBcDgiaGoPA5T8" target="_blank" rel="noopener">submit the form →</a>. Watch APDA’s Schedule and 25–26 sheet for updates.</p>
+          <p class="about-preview" style="margin:.25rem 0 .4rem;">Motion tournament hosted by Johns Hopkins UDC on the Homewood campus. Roster is confirmed; watch APDA’s Schedule and the 25–26 sheet for updates.</p>
           <div class="cta-row">
             <a class="link-chip" href="calendar.html">Calendar →</a>
             <a class="link-chip" href="https://drive.google.com/drive/folders/1SIot57czQp_hxY6Bx38I_SN4deVhbvDo?usp=drive_link" target="_blank" rel="noopener">TID →</a>
-            <a class="link-chip" href="https://forms.gle/sEoHBcDgiaGoPA5T8" target="_blank" rel="noopener">Sign up →</a>
           </div>
         </article>
 


### PR DESCRIPTION
## Summary
- mark Johns Hopkins Novice (APDA) as roster confirmed across the featured, event, and dashboard sections
- remove obsolete sign-up calls-to-action now that the roster is finalized and direct members to travel updates

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68d89f910ccc8322b499d6e58089a256