### PR TITLE
Update Johns Hopkins judges chip copy

### DIFF
--- a/tournaments.html
+++ b/tournaments.html
@@ -247,11 +247,11 @@
             <span class="pill confirmed">Roster Confirmed</span>
           </div>
           <div class="event-badges">
-            <span class="badge-need" data-judges-needed="3" title="Estimated judges needed">
+            <span class="badge-need" data-judges-needed="covered" title="Judging obligation covered">
               <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
                 <path d="M7.5 7.5l4 4 5-5-4-4-5 5zm-1.4 1.4l-1.1 3.3 3.2-1.2 8-8-2.1-2.1-8 8zM3 21h18v-2H3v2z"/>
               </svg>
-              <span class="badge-text">Judges needed: <strong class="need-count">3</strong></span>
+              <span class="badge-text"><strong class="need-count">Judges confirmed</strong></span>
             </span>
           </div>
           <div class="meta">
@@ -260,7 +260,7 @@
           </div>
           <p class="muted">Part of APDA’s annual novice weekend and hosted by the Johns Hopkins Undergraduate Debate Council on the Homewood campus in Baltimore.</p>
           <ul class="section-list" style="margin-top:.6rem;">
-            <li><strong>Roster:</strong> Confirmed — travel pairings and judge assignments are set.</li>
+            <li><strong>Roster:</strong> Confirmed — travel pairings and judge assignments are in the Johns Hopkins TID.</li>
             <li><strong>Division:</strong> Novice-only field; APDA motion sets</li>
             <li><strong>Funding:</strong> PDU covers travel, registration, lodging.</li>
             <li><strong>Details:</strong> APDA’s Schedule page and the public 25–26 Scheduling Sheet already list the event; expect the full invite on the APDA Forum (login required).</li>
@@ -269,7 +269,7 @@
             <a class="link-chip" href="calendar.html">Add/See on Calendar →</a>
             <a class="link-chip" href="https://drive.google.com/drive/folders/1SIot57czQp_hxY6Bx38I_SN4deVhbvDo?usp=drive_link" target="_blank" rel="noopener">TID (Drive) →</a>
           </div>
-          <p class="note">Roster confirmed — Travel Directors will share logistics and any waitlist updates directly.</p>
+          <p class="note">Roster confirmed — Travel Directors will share updates, and full logistics live in the Johns Hopkins TID (link above).</p>
         </div>
 
         <aside class="feature-right">
@@ -295,18 +295,18 @@
             <span class="pill confirmed">Roster Confirmed</span>
           </div>
           <div class="event-badges">
-            <span class="badge-need" data-judges-needed="3" title="Estimated judges needed">
+            <span class="badge-need" data-judges-needed="covered" title="Judging obligation covered">
               <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
                 <path d="M7.5 7.5l4 4 5-5-4-4-5 5zm-1.4 1.4l-1.1 3.3 3.2-1.2 8-8-2.1-2.1-8 8zM3 21h18v-2H3v2z"/>
               </svg>
-              <span class="badge-text">Judges needed: <strong class="need-count">3</strong></span>
+              <span class="badge-text"><strong class="need-count">Judges confirmed</strong></span>
             </span>
           </div>
           <div class="meta">
             <span class="chip">Motion Tournament</span>
             <span class="chip">Oct 3–4</span>
           </div>
-          <p class="about-preview" style="margin:.25rem 0 .4rem;">Motion tournament hosted by Johns Hopkins UDC on the Homewood campus. Roster is confirmed; watch APDA’s Schedule and the 25–26 sheet for updates.</p>
+          <p class="about-preview" style="margin:.25rem 0 .4rem;">Motion tournament hosted by Johns Hopkins UDC on the Homewood campus. Roster is confirmed; logistics and judging details are in the Johns Hopkins TID.</p>
           <div class="cta-row">
             <a class="link-chip" href="calendar.html">Calendar →</a>
             <a class="link-chip" href="https://drive.google.com/drive/folders/1SIot57czQp_hxY6Bx38I_SN4deVhbvDo?usp=drive_link" target="_blank" rel="noopener">TID →</a>


### PR DESCRIPTION
## Summary
- change the Johns Hopkins judge status badge copy to say "Judges confirmed"

## Testing
- none

------
https://chatgpt.com/codex/tasks/task_e_68d8a222b8c083228daa5d4f6b0df169