### PR TITLE
Update Johns Hopkins judges chip text

### DIFF
--- a/tournaments.html
+++ b/tournaments.html
@@ -251,7 +251,7 @@
               <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
                 <path d="M7.5 7.5l4 4 5-5-4-4-5 5zm-1.4 1.4l-1.1 3.3 3.2-1.2 8-8-2.1-2.1-8 8zM3 21h18v-2H3v2z"/>
               </svg>
-              <span class="badge-text"><strong class="need-count">Judges covered</strong></span>
+              <span class="badge-text"><strong class="need-count">Judges confirmed</strong></span>
             </span>
           </div>
           <div class="meta">
@@ -299,7 +299,7 @@
               <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
                 <path d="M7.5 7.5l4 4 5-5-4-4-5 5zm-1.4 1.4l-1.1 3.3 3.2-1.2 8-8-2.1-2.1-8 8zM3 21h18v-2H3v2z"/>
               </svg>
-              <span class="badge-text"><strong class="need-count">Judges covered</strong></span>
+              <span class="badge-text"><strong class="need-count">Judges confirmed</strong></span>
             </span>
           </div>
           <div class="meta">


### PR DESCRIPTION
## Summary
- adjust the Johns Hopkins tournament judging badge label so the chip reads “Judges confirmed”

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8a527de608322b44a8f87f6382cdb