### PR TITLE
Open Harvard tournament sign-ups

### DIFF
--- a/index.html
+++ b/index.html
@@ -549,11 +549,14 @@
         <article class="event-card">
           <div class="event-head">
             <h4>Harvard</h4>
-            <span class="pill tentative">Tentative</span>
+            <span class="pill open">Sign-ups open</span>
           </div>
           <p class="event-meta">Oct 10–11 · Cambridge, MA</p>
-          <p class="event-note">APDA Meeting.</p>
-          <a class="link-chip" href="tournaments.html">Details →</a>
+          <p class="event-note">Our second-largest tournament of the season — throw your hat in the ring against dozens of other schools or join for a free trip to Boston and the APDA meeting.</p>
+          <div class="cta-row" style="gap:.4rem;">
+            <a class="link-chip" href="https://forms.gle/vso1PP49tk6djohC7" target="_blank" rel="noopener">Sign up →</a>
+            <a class="link-chip" href="tournaments.html">Details →</a>
+          </div>
         </article>
 
         <article class="event-card">

--- a/join.html
+++ b/join.html
@@ -423,7 +423,7 @@
           <h4>October</h4>
           <ul>
             <li>Casebuilding workshop</li>
-              <li>Travel: Johns Hopkins Novice (APDA) — APDA novice weekend motion tournament Oct 3–4 in Baltimore (roster confirmed); Harvard (APDA Meeting, tentative); Brown (tentative)</li>
+              <li>Travel: Johns Hopkins Novice (APDA) — APDA novice weekend motion tournament Oct 3–4 in Baltimore (roster confirmed); <a href="https://forms.gle/vso1PP49tk6djohC7" target="_blank" rel="noopener">Harvard sign-ups</a> now open for the second-largest tournament of the season (APDA Meeting); Brown (tentative)</li>
             <li>Novice spotlight night</li>
           </ul>
           <div class="cta-row"><a class="link-chip" href="calendar.html">Open calendar →</a></div>

--- a/members.html
+++ b/members.html
@@ -288,7 +288,7 @@
           <div class="dash-card accent-warn span-5">
             <h3 class="about-header" style="margin-top:.1rem;">Upcoming Travel  -  Overview</h3>
             <p class="about-preview" style="margin-bottom:.75rem;">
-              First stop: Johns Hopkins Novice (APDA) — APDA novice weekend motion tournament Oct 3–4 in Baltimore. Roster is confirmed; Harvard and Brown follow later in the month.
+              First stop: Johns Hopkins Novice (APDA) — APDA novice weekend motion tournament Oct 3–4 in Baltimore. Roster is confirmed; Harvard sign-ups are live for our second-largest trip of the season before Brown closes out the month.
             </p>
 
             <div class="targets-grid overview">
@@ -304,11 +304,12 @@
               </article>
 
               <article class="target-card">
-                <span class="pill tentative">Tentative</span>
+                <span class="pill open">Sign-ups open</span>
                 <div class="chip-row"><span class="chip">Oct 10–11</span><span class="chip">Harvard</span></div>
                 <h3>Harvard</h3>
-                <p class="about-preview" style="margin:.55rem 0 .65rem;">Includes APDA meeting.</p>
+                <p class="about-preview" style="margin:.55rem 0 .65rem;">Second-largest tournament of the season. Throw your hat in the ring against dozens of other schools or come for the free trip to Boston and the APDA meeting.</p>
                 <div class="cta-row">
+                  <a class="link-chip" href="https://forms.gle/vso1PP49tk6djohC7" target="_blank" rel="noopener">Sign up →</a>
                   <a class="link-chip" href="tournaments.html">Details →</a>
                   <a class="link-chip" href="calendar.html">Calendar →</a>
                 </div>
@@ -336,7 +337,7 @@
             <h4>October</h4>
             <ul>
               <li>Mon/Wed meetings · 7:00 PM</li>
-              <li>Travel: Johns Hopkins Novice (APDA) — APDA novice weekend motion tournament Oct 3–4 in Baltimore · Harvard (APDA Meeting) · Brown</li>
+              <li>Travel: Johns Hopkins Novice (APDA) — APDA novice weekend motion tournament Oct 3–4 in Baltimore · Harvard sign-ups open for the second-largest tournament of the season (APDA Meeting) · Brown</li>
             </ul>
             <div class="cta-row"><a class="link-chip" href="tournaments.html#october">See slate →</a></div>
           </div>

--- a/tournaments.html
+++ b/tournaments.html
@@ -317,7 +317,7 @@
         <article class="target-card" role="listitem">
           <div class="event-head">
             <h4>Harvard</h4>
-            <span class="pill tentative">Tentative</span>
+            <span class="pill open">Sign-ups open</span>
           </div>
           <div class="event-badges">
             <span class="badge-need" data-judges-needed="tbd" title="Estimated judges needed">
@@ -331,8 +331,9 @@
             <span class="chip">APDA Meeting</span>
             <span class="chip">Oct 10–11</span>
           </div>
-          <p class="about-preview" style="margin:.25rem 0 .4rem;">Includes APDA meeting.</p>
+          <p class="about-preview" style="margin:.25rem 0 .4rem;">Sign up for the second-largest tournament of the season, meet dozens of other schools, and join the APDA meeting — or just tag along for a free trip to Boston.</p>
           <div class="cta-row">
+            <a class="link-chip" href="https://forms.gle/vso1PP49tk6djohC7" target="_blank" rel="noopener">Sign up →</a>
             <a class="link-chip" href="calendar.html">Calendar →</a>
             <a class="link-chip" href="https://drive.google.com/drive/folders/1SIot57czQp_hxY6Bx38I_SN4deVhbvDo?usp=drive_link" target="_blank" rel="noopener">TID →</a>
           </div>


### PR DESCRIPTION
## Summary
- mark the Harvard APDA meeting tournament as open for sign-ups across tournaments, index, members, and join pages
- add new flavour text that highlights it as the second-largest trip of the season and encourages students to join the Boston travel squad
- link the Google form so members can respond directly from each call-to-action

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dda88df1988322937c22c50b15ea7e