### PR TITLE
Remove reimbursement mention from finance bio

### DIFF
--- a/leadership.html
+++ b/leadership.html
@@ -382,7 +382,7 @@
               data-role="Finance"
               data-img="pranav.jpg"
               data-email="pg2782@nyu.edu"
-              data-bio="Manages budgets, reimbursements, and funding so members can focus on growing as debaters.">
+              data-bio="Manages budgets and funding so members can focus on growing as debaters.">
         <div class="leader-media"><img loading="lazy" src="pranav.jpg" alt="Portrait of Pranav Gupta"></div>
         <div class="leader-info">
           <h3 class="leader-name">Pranav Gupta</h3>


### PR DESCRIPTION
## Summary
- update the finance director biography to remove mention of reimbursements while retaining the focus on budgets and funding

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68deb636d9748322b181bf94bc990d6f