### PR TITLE
Refine Hopkins passed tournament messaging

### DIFF
--- a/tournaments.html
+++ b/tournaments.html
@@ -38,6 +38,8 @@
     .pill.open       { background:rgba(80,200,120,.12);  border-color:rgba(80,200,120,.45); }
     .pill.tentative  { background:rgba(255,200,80,.12);  border-color:rgba(255,200,80,.45); }
     .pill.confirmed  { background:rgba(120,180,255,.12); border-color:rgba(120,180,255,.45); }
+    .pill.closed     { background:rgba(255,120,120,.14); border-color:rgba(255,120,120,.45); }
+    .pill.passed     { background:rgba(180,180,200,.12); border-color:rgba(180,180,200,.35); }
 
     /* Featured tournament */
     .feature-card {
@@ -224,6 +226,7 @@
     <nav class="toc-list">
       <a href="#featured" class="active">Featured Tournament</a>
       <a href="#upcoming">Upcoming Targets</a>
+      <a href="#passed">Passed Tournaments</a>
       <a href="#achievements">Notable Achievements</a>
       <a href="#judging">Judging</a>
       <a href="#primer">How APDA Works</a>
@@ -243,81 +246,8 @@
       <div class="feature-card">
         <div class="feature-left">
           <div class="event-head">
-            <h3>Johns Hopkins Novice (APDA)</h3>
-            <span class="pill confirmed">Roster Confirmed</span>
-          </div>
-          <div class="event-badges">
-            <span class="badge-need" data-judges-needed="covered" title="Judging obligation covered">
-              <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
-                <path d="M7.5 7.5l4 4 5-5-4-4-5 5zm-1.4 1.4l-1.1 3.3 3.2-1.2 8-8-2.1-2.1-8 8zM3 21h18v-2H3v2z"/>
-              </svg>
-              <span class="badge-text"><strong class="need-count">Judges confirmed</strong></span>
-            </span>
-          </div>
-          <div class="meta">
-            <span class="chip">Motion Tournament</span>
-            <span class="chip">Oct 3–4</span>
-          </div>
-          <p class="muted">Part of APDA’s annual novice weekend and hosted by the Johns Hopkins Undergraduate Debate Council on the Homewood campus in Baltimore.</p>
-          <ul class="section-list" style="margin-top:.6rem;">
-            <li><strong>Roster:</strong> Confirmed — travel pairings and judge assignments are in the Johns Hopkins TID.</li>
-            <li><strong>Division:</strong> Novice-only field; APDA motion sets</li>
-            <li><strong>Funding:</strong> PDU covers travel, registration, lodging.</li>
-            <li><strong>Details:</strong> APDA’s Schedule page and the public 25–26 Scheduling Sheet already list the event; expect the full invite on the APDA Forum (login required).</li>
-          </ul>
-          <div class="cta-row" style="margin-top:.75rem;">
-            <a class="link-chip" href="calendar.html">Add/See on Calendar →</a>
-            <a class="link-chip" href="https://drive.google.com/drive/folders/1SIot57czQp_hxY6Bx38I_SN4deVhbvDo?usp=drive_link" target="_blank" rel="noopener">TID (Drive) →</a>
-          </div>
-          <p class="note">Roster confirmed — Travel Directors will share updates, and full logistics live in the Johns Hopkins TID (link above).</p>
-        </div>
-
-        <aside class="feature-right">
-          <h4>What to expect</h4>
-          <ul class="section-list">
-            <li>Hosted on Johns Hopkins’ Homewood campus in Baltimore, MD</li>
-            <li>Novice-exclusive stop on APDA’s fall schedule</li>
-            <li>5 prelim rounds using APDA motion sets, then break to elims</li>
-            <li>Meals typically provided by host; pack formal casual and bring photo ID</li>
-          </ul>
-        </aside>
-      </div>
-    </section>
-
-    <!-- Upcoming Targets grid -->
-    <section class="glass-card reveal" id="upcoming">
-      <h3 class="about-header">Upcoming Targets</h3>
-      <div class="targets-grid" role="list">
-        <!-- Johns Hopkins Novice (APDA) -->
-        <article class="target-card" role="listitem">
-          <div class="event-head">
-            <h4>Johns Hopkins Novice (APDA)</h4>
-            <span class="pill confirmed">Roster Confirmed</span>
-          </div>
-          <div class="event-badges">
-            <span class="badge-need" data-judges-needed="covered" title="Judging obligation covered">
-              <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
-                <path d="M7.5 7.5l4 4 5-5-4-4-5 5zm-1.4 1.4l-1.1 3.3 3.2-1.2 8-8-2.1-2.1-8 8zM3 21h18v-2H3v2z"/>
-              </svg>
-              <span class="badge-text"><strong class="need-count">Judges confirmed</strong></span>
-            </span>
-          </div>
-          <div class="meta">
-            <span class="chip">Motion Tournament</span>
-            <span class="chip">Oct 3–4</span>
-          </div>
-          <p class="about-preview" style="margin:.25rem 0 .4rem;">Motion tournament hosted by Johns Hopkins UDC on the Homewood campus. Roster is confirmed; logistics and judging details are in the Johns Hopkins TID.</p>
-          <div class="cta-row">
-            <a class="link-chip" href="calendar.html">Calendar →</a>
-            <a class="link-chip" href="https://drive.google.com/drive/folders/1SIot57czQp_hxY6Bx38I_SN4deVhbvDo?usp=drive_link" target="_blank" rel="noopener">TID →</a>
-          </div>
-        </article>
-
-        <!-- Harvard (APDA Meeting) -->
-        <article class="target-card" role="listitem">
-          <div class="event-head">
-            <h4>Harvard</h4>
-            <span class="pill open">Sign-ups open</span>
+            <h3>Harvard</h3>
+            <span class="pill closed">Sign-ups closed</span>
           </div>
           <div class="event-badges">
             <span class="badge-need" data-judges-needed="tbd" title="Estimated judges needed">
@@ -331,9 +261,56 @@
             <span class="chip">APDA Meeting</span>
             <span class="chip">Oct 10–11</span>
           </div>
-          <p class="about-preview" style="margin:.25rem 0 .4rem;">Sign up for the second-largest tournament of the season, meet dozens of other schools, and join the APDA meeting — or just tag along for a free trip to Boston.</p>
+          <p class="muted">The next major stop on the circuit. We’re finalizing travel plans, housing, and the APDA meeting schedule — keep an eye out for TID updates as details lock in.</p>
+          <ul class="section-list" style="margin-top:.6rem;">
+            <li><strong>Roster:</strong> TBD — selections will be announced in Slack.</li>
+            <li><strong>Travel & housing:</strong> TBD — accommodations and transit plan will post in the Harvard TID.</li>
+            <li><strong>Schedule:</strong> TBD — expect full invite timing and APDA meeting agenda soon.</li>
+            <li><strong>Judging:</strong> TBD — we’ll confirm obligations once the field size is released.</li>
+          </ul>
+          <div class="cta-row" style="margin-top:.75rem;">
+            <a class="link-chip" href="calendar.html">Add/See on Calendar →</a>
+            <a class="link-chip" href="https://drive.google.com/drive/folders/1SIot57czQp_hxY6Bx38I_SN4deVhbvDo?usp=drive_link" target="_blank" rel="noopener">Harvard TID (Drive) →</a>
+          </div>
+          <p class="note">Sign-ups are closed — if you expressed interest, watch Slack for roster announcements and logistics.</p>
+        </div>
+
+        <aside class="feature-right">
+          <h4>What to prep</h4>
+          <ul class="section-list">
+            <li>Review the latest APDA motions packet and refresh rebuttal drills.</li>
+            <li>Coordinate with your partner on case brainstorming — Harvard fields are deep.</li>
+            <li>Pack layers for Boston in October and keep IDs handy for campus access.</li>
+            <li>Check the TID for meet-up times as soon as updates drop.</li>
+          </ul>
+        </aside>
+      </div>
+    </section>
+
+    <!-- Upcoming Targets grid -->
+    <section class="glass-card reveal" id="upcoming">
+      <h3 class="about-header">Upcoming Targets</h3>
+      <div class="targets-grid" role="list">
+        <!-- Harvard (APDA Meeting) -->
+        <article class="target-card" role="listitem">
+          <div class="event-head">
+            <h4>Harvard</h4>
+            <span class="pill closed">Sign-ups closed</span>
+          </div>
+          <div class="event-badges">
+            <span class="badge-need" data-judges-needed="tbd" title="Estimated judges needed">
+              <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M7.5 7.5l4 4 5-5-4-4-5 5zm-1.4 1.4l-1.1 3.3 3.2-1.2 8-8-2.1-2.1-8 8zM3 21h18v-2H3v2z"/>
+              </svg>
+              <span class="badge-text">Judges needed: <strong class="need-count">TBD</strong></span>
+            </span>
+          </div>
+          <div class="meta">
+            <span class="chip">APDA Meeting</span>
+            <span class="chip">Oct 10–11</span>
+          </div>
+          <p class="about-preview" style="margin:.25rem 0 .4rem;">The biggest fall trip is next — we’re locking in travel, judges, and room blocks. Watch Slack for roster announcements and logistics drops.</p>
           <div class="cta-row">
-            <a class="link-chip" href="https://forms.gle/vso1PP49tk6djohC7" target="_blank" rel="noopener">Sign up →</a>
             <a class="link-chip" href="calendar.html">Calendar →</a>
             <a class="link-chip" href="https://drive.google.com/drive/folders/1SIot57czQp_hxY6Bx38I_SN4deVhbvDo?usp=drive_link" target="_blank" rel="noopener">TID →</a>
           </div>
@@ -411,6 +388,36 @@
           <div class="cta-row">
             <a class="link-chip" href="calendar.html">Calendar →</a>
             <a class="link-chip" href="https://drive.google.com/drive/folders/1SIot57czQp_hxY6Bx38I_SN4deVhbvDo?usp=drive_link" target="_blank" rel="noopener">TID →</a>
+          </div>
+        </article>
+      </div>
+    </section>
+
+    <!-- Passed Tournaments -->
+    <section class="glass-card reveal" id="passed">
+      <h3 class="about-header">Passed Tournaments</h3>
+      <div class="targets-grid" role="list">
+        <article class="target-card" role="listitem">
+          <div class="event-head">
+            <h4>Johns Hopkins Novice (APDA)</h4>
+            <span class="pill passed">Passed</span>
+          </div>
+          <div class="event-badges">
+            <span class="badge-need ok" data-judges-needed="0" title="Judging obligation covered">
+              <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M7.5 7.5l4 4 5-5-4-4-5 5zm-1.4 1.4l-1.1 3.3 3.2-1.2 8-8-2.1-2.1-8 8zM3 21h18v-2H3v2z"/>
+              </svg>
+              <span class="badge-text"><strong class="need-count">Covered</strong></span>
+            </span>
+          </div>
+          <div class="meta">
+            <span class="chip">Motion Tournament</span>
+            <span class="chip">Oct 3–4</span>
+          </div>
+          <p class="about-preview" style="margin:.25rem 0 .4rem;">Thanks to everyone who travelled to Baltimore for novice weekend! Check Recent Highlights for the recap and shout-outs.</p>
+          <div class="cta-row">
+            <a class="link-chip" href="calendar.html">Calendar →</a>
+            <a class="link-chip" href="index.html#recent-highlights">Recent Highlights →</a>
           </div>
         </article>
       </div>


### PR DESCRIPTION
## Summary
- update the Hopkins passed tournament blurb to reference Recent Highlights instead of reimbursements
- swap the TID call-to-action for a Recent Highlights link chip to avoid pointing at the drive folder

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e2a4b867c88322ae1974e996d2ec67