### PR TITLE
Update site to feature Harvard APDA trip

### DIFF
--- a/index.html
+++ b/index.html
@@ -513,15 +513,16 @@
     <section class="featured-wrap reveal" id="featured">
       <div class="featured-card">
         <div>
-          <h3 class="about-header" style="margin-bottom:.4rem;">Featured: Johns Hopkins Novice (APDA)</h3>
+          <h3 class="about-header" style="margin-bottom:.4rem;">Featured: Harvard (APDA Meeting)</h3>
           <div class="featured-meta">
-            <span class="chip">Oct 3–4</span>
-            <span class="chip">Baltimore, MD</span>
-            <span class="chip">Motion Tournament</span>
+            <span class="chip">Oct 10–11</span>
+            <span class="chip">Cambridge, MA</span>
+            <span class="chip">APDA Meeting</span>
           </div>
-          <p class="about-preview" style="margin:.25rem 0 0;">APDA novice weekend stop hosted by Johns Hopkins UDC on the Homewood campus. The travel roster is confirmed; logistics updates will be shared with the team.</p>
+          <p class="about-preview" style="margin:.25rem 0 0;">The next major trip on the fall circuit. Roster and judging are locked — check the Harvard TID for rolling travel and housing updates as they’re posted.</p>
           <div class="cta-row" style="margin-top:.6rem;">
-            <a class="link-chip" href="tournaments.html">Event details →</a>
+            <a class="link-chip" href="tournaments.html#featured">Event details →</a>
+            <a class="link-chip" href="https://drive.google.com/drive/folders/1SIot57czQp_hxY6Bx38I_SN4deVhbvDo?usp=drive_link" target="_blank" rel="noopener">Harvard TID →</a>
           </div>
         </div>
         <div class="featured-side">
@@ -534,18 +535,6 @@
     <section class="section-wrap reveal" aria-label="More upcoming tournaments">
       <h3 class="about-header">Upcoming Tournaments</h3>
       <div class="h-scroll">
-        <article class="event-card">
-          <div class="event-head">
-            <h4>Johns Hopkins Novice (APDA)</h4>
-            <span class="pill confirmed">Roster Confirmed</span>
-          </div>
-          <p class="event-meta">Oct 3–4 · Baltimore, MD</p>
-          <p class="event-note">Motion tournament during APDA novice weekend hosted by Johns Hopkins UDC. Roster confirmed; coordinators will send travel details directly.</p>
-          <div class="cta-row" style="gap:.4rem;">
-            <a class="link-chip" href="tournaments.html">Details →</a>
-          </div>
-        </article>
-
         <article class="event-card">
           <div class="event-head">
             <h4>Harvard</h4>

--- a/join.html
+++ b/join.html
@@ -415,7 +415,7 @@
           <ul>
             <li>Kickoff lessons begin</li>
             <li>First scrim night</li>
-              <li>Travel: Prep for Johns Hopkins Novice (APDA) — APDA novice weekend motion tournament Oct 3–4 in Baltimore. Roster confirmed; travel briefing during meetings.</li>
+              <li>Travel: Prep for Harvard (APDA Meeting) — Oct 10–11 in Cambridge. Roster confirmed; travel briefing during meetings.</li>
           </ul>
           <div class="cta-row"><a class="link-chip" href="calendar.html">Open calendar →</a></div>
         </div>
@@ -423,7 +423,7 @@
           <h4>October</h4>
           <ul>
             <li>Casebuilding workshop</li>
-              <li>Travel: Johns Hopkins Novice (APDA) — APDA novice weekend motion tournament Oct 3–4 in Baltimore (roster confirmed); Harvard roster confirmed with judging covered for the APDA Meeting trip; Brown (tentative)</li>
+              <li>Travel: Harvard (APDA Meeting) — Oct 10–11 in Cambridge (roster & judging confirmed); Brown (tentative); Johns Hopkins recap shared in Highlights</li>
             <li>Novice spotlight night</li>
           </ul>
           <div class="cta-row"><a class="link-chip" href="calendar.html">Open calendar →</a></div>

--- a/members.html
+++ b/members.html
@@ -249,7 +249,7 @@
       <div class="dash-card accent-info span-12">
         <div class="stat-row">
           <span class="stat-chip"><i class="dot purple blink"></i> <span id="memberCountdown">Calculating next meeting…</span></span>
-          <span class="stat-chip"><i class="dot purple"></i> Next tournament: <strong>Oct 3–4</strong></span>
+          <span class="stat-chip"><i class="dot purple"></i> Next tournament: <strong>Oct 10–11</strong></span>
           <a class="stat-chip attendance-link" href="https://forms.gle/HEqqch1fvxPHEvKt6" target="_blank" rel="noopener">
             <i class="dot green"></i>
             Mark your attendance →
@@ -288,30 +288,30 @@
           <div class="dash-card accent-warn span-5">
             <h3 class="about-header" style="margin-top:.1rem;">Upcoming Travel  -  Overview</h3>
             <p class="about-preview" style="margin-bottom:.75rem;">
-              First stop: Johns Hopkins Novice (APDA) — APDA novice weekend motion tournament Oct 3–4 in Baltimore. Roster is confirmed; Harvard’s roster is now locked with judging covered ahead of Brown closing out the month.
+              Next up: Harvard (APDA Meeting) — Oct 10–11 in Cambridge. Roster and judging are locked; Brown closes the month once details finalize. Huge thanks to everyone who wrapped Johns Hopkins Novice — recap incoming.
             </p>
 
             <div class="targets-grid overview">
               <article class="target-card">
                 <span class="pill confirmed">Roster Confirmed</span>
-                <div class="chip-row"><span class="chip">Oct 3–4</span><span class="chip">Johns Hopkins Novice (APDA)</span></div>
-                <h3>Johns Hopkins Novice (APDA)</h3>
-                <p class="about-preview" style="margin:.55rem 0 .65rem;">APDA novice weekend motion tournament on Johns Hopkins’ Homewood campus. Roster is confirmed; watch for travel logistics from the directors.</p>
+                <div class="chip-row"><span class="chip">Oct 10–11</span><span class="chip">Harvard</span></div>
+                <h3>Harvard (APDA Meeting)</h3>
+                <p class="about-preview" style="margin:.55rem 0 .65rem;">Second-largest trip of the season. Roster and judges are locked; review the Harvard TID and Slack for travel timelines and housing assignments.</p>
                 <div class="cta-row">
                   <a class="link-chip" href="tournaments.html">Details →</a>
+                  <a class="link-chip" href="https://drive.google.com/drive/folders/1SIot57czQp_hxY6Bx38I_SN4deVhbvDo?usp=drive_link" target="_blank" rel="noopener">Harvard TID →</a>
                   <a class="link-chip" href="calendar.html">Calendar →</a>
                 </div>
               </article>
 
               <article class="target-card">
-                <span class="pill confirmed">Roster Confirmed</span>
-                <div class="chip-row"><span class="chip">Oct 10–11</span><span class="chip">Harvard</span></div>
-                <h3>Harvard</h3>
-                <p class="about-preview" style="margin:.55rem 0 .65rem;">Second-largest tournament of the season. Roster and judges are locked; review the Harvard TID and Slack for travel timelines and housing assignments.</p>
+                <span class="pill passed">Passed</span>
+                <div class="chip-row"><span class="chip">Oct 3–4</span><span class="chip">Johns Hopkins Novice</span></div>
+                <h3>Johns Hopkins Recap</h3>
+                <p class="about-preview" style="margin:.55rem 0 .65rem;">Baltimore is in the books! Look for shout-outs in Recent Highlights and share photos for the drive.</p>
                 <div class="cta-row">
-                  <a class="link-chip" href="tournaments.html">Details →</a>
-                  <a class="link-chip" href="https://drive.google.com/drive/folders/1SIot57czQp_hxY6Bx38I_SN4deVhbvDo?usp=drive_link" target="_blank" rel="noopener">Harvard TID →</a>
-                  <a class="link-chip" href="calendar.html">Calendar →</a>
+                  <a class="link-chip" href="index.html#recent-highlights">Highlights →</a>
+                  <a class="link-chip" href="tournaments.html#passed">Passed tournaments →</a>
                 </div>
               </article>
 
@@ -337,7 +337,7 @@
             <h4>October</h4>
             <ul>
               <li>Mon/Wed meetings · 7:00 PM</li>
-              <li>Travel: Johns Hopkins Novice (APDA) — APDA novice weekend motion tournament Oct 3–4 in Baltimore · Harvard roster confirmed and judging covered for the APDA Meeting trip · Brown</li>
+              <li>Travel: Harvard (APDA Meeting) — Oct 10–11 in Cambridge (roster & judging confirmed); Brown (tentative) later in the month; Johns Hopkins recap drops in Highlights</li>
             </ul>
             <div class="cta-row"><a class="link-chip" href="tournaments.html#october">See slate →</a></div>
           </div>
@@ -412,14 +412,15 @@
               <div class="announce">
                 <article class="target-card">
                   <span class="pill confirmed">Travel Update</span>
-                  <h4>Johns Hopkins Novice: Roster finalized</h4>
-                  <p class="about-preview">The roster is set for the Oct 3–4 Johns Hopkins Novice (APDA) weekend. Travel directors are distributing pairings, judging assignments, and logistics.</p>
+                  <h4>Harvard: Final logistics posted</h4>
+                  <p class="about-preview">Roster is locked for the Oct 10–11 Harvard (APDA Meeting) trip. Travel and housing assignments are live in the TID with updates mirrored to Slack.</p>
                   <ul class="about-preview">
-                    <li><strong>Who:</strong> Confirmed travelers and judges — check your email and Slack for itinerary details.</li>
-                    <li><strong>Action:</strong> Reach out to Travel if you have conflicts or need accessibility accommodations.</li>
+                    <li><strong>Who:</strong> Confirmed travelers and judges — review the TID for call times and rooming notes.</li>
+                    <li><strong>Action:</strong> DM Travel if anything changes or if you need accessibility accommodations.</li>
                   </ul>
                   <div class="cta-row">
                     <a class="link-chip" href="tournaments.html#featured">Event details →</a>
+                    <a class="link-chip" href="https://drive.google.com/drive/folders/1SIot57czQp_hxY6Bx38I_SN4deVhbvDo?usp=drive_link" target="_blank" rel="noopener">Harvard TID →</a>
                   </div>
                 </article>
               </div>


### PR DESCRIPTION
## Summary
- feature Harvard (APDA Meeting) as the next tournament on the home page and remove Johns Hopkins from the upcoming strip
- refresh the members dashboard to highlight Harvard logistics, shift Johns Hopkins to recap status, and update October travel notes
- update join page month-at-a-glance travel bullets to reflect Harvard as the current focus and Johns Hopkins as a completed event

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68e2aab3160883228612ac59f958f68f