### PR TITLE
Polish John Hopkins novice highlights gallery

### DIFF
--- a/index.html
+++ b/index.html
@@ -489,23 +489,40 @@
       </article>
     </section>
 
-    <!-- Notable Achievements -->
-    <section class="glass-card reveal" id="home-achievements">
-      <h3 class="about-header">Notable Achievements</h3>
-      <h4 class="year-badge">2024–25</h4>
-      <div class="achievement-grid">
-        <div class="achievement-card"><span class="achievement-icon">🏆</span>UVA Tournament, 5th best varsity speaker</div>
-        <div class="achievement-card"><span class="achievement-icon">🏆</span>American University Tournament, 6th best varsity speaker</div>
-        <div class="achievement-card"><span class="achievement-icon">🏆</span>Columbia University Tournament, 10th best varsity team</div>
+    <!-- Recent Highlights -->
+    <section class="glass-card highlight-card reveal" id="recent-highlights">
+      <div class="highlight-copy">
+        <h3 class="about-header">Recent Highlights: John Hopkins Novice Tournament</h3>
+        <p class="highlight-lead">Thank you to every debater who traveled to Baltimore for the John Hopkins Novice Tournament—your energy carried through every round and every hallway conversation.</p>
+        <p class="highlight-shout"><strong>Standout teams:</strong> Charamine Tan &amp; Wesley Liu and Abhi Sharma &amp; Sahil Chatwal were our highest-performing NYU pairings, closing the weekend with a sharp 4-2 record.</p>
+        <p class="highlight-tagline">Want to attend tournaments like this? Plug into the travel roster and stay ready for the next departure.</p>
+        <div class="highlight-tags" aria-label="Links to join PDU and view the calendar">
+          <a class="tag-link spark-tag" href="join.html">Join PDU</a>
+          <a class="tag-link spark-tag" href="calendar.html">Check the calendar</a>
+        </div>
       </div>
-      <h4 class="year-badge">2023–24</h4>
-      <div class="achievement-grid">
-        <div class="achievement-card"><span class="achievement-icon">🏆</span>2nd best team of the year, Ailin Jia and Aadhavaarasan Raviarasan</div>
-        <div class="achievement-card"><span class="achievement-icon">🏆</span>8th best club of the year</div>
-        <div class="achievement-card"><span class="achievement-icon">🏆</span>2nd best speaker of the year, Aadhavaarasan Raviarasan</div>
-      </div>
-      <div class="cta-row">
-        <a class="link-chip" href="tournaments.html#achievements">More details →</a>
+      <div class="highlight-gallery" aria-label="Highlights from the John Hopkins Novice Tournament weekend">
+        <figure class="highlight-hero">
+          <img src="20251004_081440.jpg" alt="NYU debaters huddled before a Hopkins novice round" loading="lazy">
+        </figure>
+        <figure class="highlight-thumb">
+          <img src="20251004_081227.jpg" alt="Morning prep before novice rounds begin" loading="lazy">
+        </figure>
+        <figure class="highlight-thumb">
+          <img src="20251004_080035.jpg" alt="Walking between buildings on the Hopkins campus" loading="lazy">
+        </figure>
+        <figure class="highlight-thumb">
+          <img src="20251003_155520.jpg" alt="Early arrival outside the tournament hotel" loading="lazy">
+        </figure>
+        <figure class="highlight-thumb">
+          <img src="20251003_161539.jpg" alt="Squad meet-up on Friday afternoon" loading="lazy">
+        </figure>
+        <figure class="highlight-thumb">
+          <img src="20251003_224823.jpg" alt="Late night strategy huddle at Hopkins" loading="lazy">
+        </figure>
+        <figure class="highlight-thumb">
+          <img src="20251003_225512.jpg" alt="Team debrief after the final round" loading="lazy">
+        </figure>
       </div>
     </section>
 
@@ -590,13 +607,23 @@
       </div>
     </section>
 
-    <!-- Recent highlight (glow message) -->
-    <section class="glass-card highlight-card recent-highlight reveal">
-      <div class="highlight-message">
-        <h3 class="about-header">Recent Highlights</h3>
-        <p class="highlight-lead">We&rsquo;re over the moon with the turnout at our September 2025 meetings&mdash;thank you for filling the room with energy and curiosity.</p>
-        <p class="highlight-shout">Extra love to everyone who jumped into the practice round; your speeches made the room crackle.</p>
-        <p class="highlight-tagline">Very impressive roster this semester.</p>
+    <!-- Notable Achievements -->
+    <section class="glass-card reveal" id="home-achievements">
+      <h3 class="about-header">Notable Achievements</h3>
+      <h4 class="year-badge">2024–25</h4>
+      <div class="achievement-grid">
+        <div class="achievement-card"><span class="achievement-icon">🏆</span>UVA Tournament, 5th best varsity speaker</div>
+        <div class="achievement-card"><span class="achievement-icon">🏆</span>American University Tournament, 6th best varsity speaker</div>
+        <div class="achievement-card"><span class="achievement-icon">🏆</span>Columbia University Tournament, 10th best varsity team</div>
+      </div>
+      <h4 class="year-badge">2023–24</h4>
+      <div class="achievement-grid">
+        <div class="achievement-card"><span class="achievement-icon">🏆</span>2nd best team of the year, Ailin Jia and Aadhavaarasan Raviarasan</div>
+        <div class="achievement-card"><span class="achievement-icon">🏆</span>8th best club of the year</div>
+        <div class="achievement-card"><span class="achievement-icon">🏆</span>2nd best speaker of the year, Aadhavaarasan Raviarasan</div>
+      </div>
+      <div class="cta-row">
+        <a class="link-chip" href="tournaments.html#achievements">More details →</a>
       </div>
     </section>
 

--- a/style.css
+++ b/style.css
@@ -318,8 +318,83 @@ nav a:hover{ color:#fff; text-shadow:0 0 8px rgba(199,191,255,.9); }
 .points li{ margin:.25rem 0; }
 
 /* ====== Highlight card ====== */
-.highlight-card{ display:grid; grid-template-columns: 1.1fr 1fr; gap:1rem; align-items:center; }
-.highlight-media img{ width:100%; height:260px; object-fit:cover; border-radius:12px; border:1px solid rgba(255,255,255,.25); }
+.highlight-card{
+  display:grid;
+  grid-template-columns:minmax(0,.95fr) minmax(0,1.05fr);
+  gap:1.5rem;
+  align-items:start;
+}
+.highlight-copy{ display:flex; flex-direction:column; gap:1rem; }
+.highlight-copy p{ line-height:1.65; }
+.highlight-lead{ font-size:1.05rem; }
+.highlight-shout strong{ color:#f4bbff; text-shadow:0 0 12px rgba(244,187,255,.4); }
+.highlight-tagline{ font-weight:500; opacity:.92; }
+.highlight-tags{ display:flex; gap:.55rem; flex-wrap:wrap; margin-top:.25rem; }
+.tag-link{
+  position:relative;
+  display:inline-flex;
+  align-items:center;
+  gap:.35rem;
+  padding:.3rem .75rem;
+  border-radius:999px;
+  font-weight:600;
+  font-size:.9rem;
+  letter-spacing:.1px;
+  text-decoration:none;
+  color:#fff;
+  background:rgba(255,255,255,.08);
+  border:1px solid rgba(255,255,255,.16);
+  transition:background .3s ease, border-color .3s ease, transform .25s ease;
+  z-index:0;
+}
+.tag-link:hover{
+  background:rgba(167,139,250,.22);
+  border-color:rgba(167,139,250,.45);
+  transform:translateY(-1px);
+}
+.tag-link:focus-visible{ outline:3px solid rgba(167,139,250,.6); outline-offset:3px; }
+.spark-tag::after{
+  content:"";
+  position:absolute;
+  inset:0;
+  border-radius:inherit;
+  background:radial-gradient(circle at 20% 30%, rgba(147,197,253,.28), transparent 65%),
+             radial-gradient(circle at 80% 70%, rgba(244,114,182,.28), transparent 70%);
+  opacity:.75;
+  mix-blend-mode:screen;
+  transition:opacity .3s ease;
+  z-index:-1;
+  pointer-events:none;
+}
+.spark-tag:hover::after{ opacity:1; }
+.spark-tag:focus-visible::after{ opacity:1; }
+
+.highlight-gallery{
+  display:grid;
+  grid-template-columns:repeat(2, minmax(0,1fr));
+  gap:.85rem;
+  align-content:start;
+  grid-auto-flow:dense;
+}
+.highlight-gallery figure{
+  position:relative;
+  overflow:hidden;
+  border-radius:14px;
+  border:1px solid rgba(255,255,255,.22);
+  background:rgba(255,255,255,.06);
+  box-shadow:0 12px 30px rgba(0,0,0,.28);
+}
+.highlight-gallery img{
+  width:100%;
+  height:100%;
+  object-fit:cover;
+  display:block;
+}
+.highlight-hero{
+  grid-column:1 / -1;
+  aspect-ratio:3/2;
+}
+.highlight-thumb{ aspect-ratio:3/4; }
 
 /* ====== CTA band ====== */
 .cta-band{
@@ -421,6 +496,8 @@ section[id] .about-header, section[id] h3, section[id] h4{ scroll-margin-top:96p
 @media (max-width:1100px){
   .tiles-quick{ grid-template-columns:1fr 1fr; }
   .highlight-card{ grid-template-columns:1fr; }
+  .highlight-gallery{ grid-template-columns:repeat(2, minmax(0,1fr)); }
+  .highlight-hero{ grid-column:span 2; }
 }
 
 @media (max-width:960px){
@@ -444,6 +521,11 @@ section[id] .about-header, section[id] h3, section[id] h4{ scroll-margin-top:96p
   .tiles-quick{ grid-template-columns:1fr; }
   .hero-title{ font-size:2.1rem; }
   .week-strip{ margin-top:-26px; }
+}
+
+@media (max-width:700px){
+  .highlight-gallery{ grid-template-columns:1fr; }
+  .highlight-hero{ grid-column:1; grid-row:auto; }
 }
 
 /* Highlight Join Us link */


### PR DESCRIPTION
## Summary
- update the Hopkins recap copy to reference the John Hopkins Novice Tournament and refresh the shout-outs and call to action
- replace the chip-style CTA with lighter tag links that still provide animated emphasis on Join and Calendar destinations
- rework the highlights gallery into a vertical grid with a dominant hero shot and six stacked supporting photos from Oct 3–4

## Testing
- python3 -m http.server 8000 (manual)


------
https://chatgpt.com/codex/tasks/task_e_68e2ada24e5c83228d0c7e2b6e256a27