### PR TITLE
Refresh Hopkins highlight layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -495,32 +495,31 @@
         <h3 class="about-header">Recent Highlights: John Hopkins Novice Tournament</h3>
         <p class="highlight-lead">Thank you to every debater who traveled to Baltimore for the John Hopkins Novice Tournament—your energy carried through every round and every hallway conversation.</p>
         <p class="highlight-shout"><strong>Standout teams:</strong> Charamine Tan &amp; Wesley Liu and Abhi Sharma &amp; Sahil Chatwal were our highest-performing NYU pairings, closing the weekend with a sharp 4-2 record.</p>
-        <p class="highlight-tagline">Want to attend tournaments like this? Plug into the travel roster and stay ready for the next departure.</p>
         <div class="highlight-tags" aria-label="Links to join PDU and view the calendar">
           <a class="tag-link spark-tag" href="join.html">Join PDU</a>
           <a class="tag-link spark-tag" href="calendar.html">Check the calendar</a>
         </div>
       </div>
+      <figure class="highlight-hero highlight-photo">
+        <img src="20251004_081440.jpg" alt="NYU debaters huddled before a Hopkins novice round" loading="lazy">
+      </figure>
       <div class="highlight-gallery" aria-label="Highlights from the John Hopkins Novice Tournament weekend">
-        <figure class="highlight-hero">
-          <img src="20251004_081440.jpg" alt="NYU debaters huddled before a Hopkins novice round" loading="lazy">
-        </figure>
-        <figure class="highlight-thumb">
+        <figure class="highlight-thumb highlight-photo">
           <img src="20251004_081227.jpg" alt="Morning prep before novice rounds begin" loading="lazy">
         </figure>
-        <figure class="highlight-thumb">
+        <figure class="highlight-thumb highlight-photo">
           <img src="20251004_080035.jpg" alt="Walking between buildings on the Hopkins campus" loading="lazy">
         </figure>
-        <figure class="highlight-thumb">
+        <figure class="highlight-thumb highlight-photo">
           <img src="20251003_155520.jpg" alt="Early arrival outside the tournament hotel" loading="lazy">
         </figure>
-        <figure class="highlight-thumb">
+        <figure class="highlight-thumb highlight-photo">
           <img src="20251003_161539.jpg" alt="Squad meet-up on Friday afternoon" loading="lazy">
         </figure>
-        <figure class="highlight-thumb">
+        <figure class="highlight-thumb highlight-photo">
           <img src="20251003_224823.jpg" alt="Late night strategy huddle at Hopkins" loading="lazy">
         </figure>
-        <figure class="highlight-thumb">
+        <figure class="highlight-thumb highlight-photo">
           <img src="20251003_225512.jpg" alt="Team debrief after the final round" loading="lazy">
         </figure>
       </div>
@@ -766,12 +765,12 @@
 
   <!-- Photo lightbox JS -->
   <script>
-    const railImgs = document.querySelectorAll('.rail-item img');
+    const lbTriggers = document.querySelectorAll('.rail-item img, .highlight-photo img');
     const lb = document.getElementById('lightbox');
     const lbImg = document.getElementById('lightboxImg');
     const lbClose = document.getElementById('lightboxClose');
 
-    railImgs.forEach(img=>{
+    lbTriggers.forEach(img=>{
       img.addEventListener('click', ()=>{
         lbImg.src = img.src;
         lbImg.alt = img.alt || '';

--- a/style.css
+++ b/style.css
@@ -321,14 +321,16 @@ nav a:hover{ color:#fff; text-shadow:0 0 8px rgba(199,191,255,.9); }
 .highlight-card{
   display:grid;
   grid-template-columns:minmax(0,.95fr) minmax(0,1.05fr);
+  grid-template-areas:
+    "copy hero"
+    "gallery gallery";
   gap:1.5rem;
   align-items:start;
 }
-.highlight-copy{ display:flex; flex-direction:column; gap:1rem; }
+.highlight-copy{ grid-area:copy; display:flex; flex-direction:column; gap:1rem; }
 .highlight-copy p{ line-height:1.65; }
 .highlight-lead{ font-size:1.05rem; }
 .highlight-shout strong{ color:#f4bbff; text-shadow:0 0 12px rgba(244,187,255,.4); }
-.highlight-tagline{ font-weight:500; opacity:.92; }
 .highlight-tags{ display:flex; gap:.55rem; flex-wrap:wrap; margin-top:.25rem; }
 .tag-link{
   position:relative;
@@ -369,31 +371,35 @@ nav a:hover{ color:#fff; text-shadow:0 0 8px rgba(199,191,255,.9); }
 .spark-tag:hover::after{ opacity:1; }
 .spark-tag:focus-visible::after{ opacity:1; }
 
+.highlight-hero{ grid-area:hero; }
 .highlight-gallery{
+  grid-area:gallery;
   display:grid;
-  grid-template-columns:repeat(2, minmax(0,1fr));
+  grid-template-columns:repeat(auto-fit, minmax(200px, 1fr));
   gap:.85rem;
   align-content:start;
   grid-auto-flow:dense;
 }
-.highlight-gallery figure{
+.highlight-photo{
   position:relative;
   overflow:hidden;
   border-radius:14px;
   border:1px solid rgba(255,255,255,.22);
   background:rgba(255,255,255,.06);
   box-shadow:0 12px 30px rgba(0,0,0,.28);
+  cursor:pointer;
 }
-.highlight-gallery img{
+.highlight-photo img{
   width:100%;
   height:100%;
   object-fit:cover;
   display:block;
 }
 .highlight-hero{
-  grid-column:1 / -1;
-  aspect-ratio:3/2;
+  min-height:320px;
+  display:flex;
 }
+.highlight-hero img{ flex:1 1 auto; }
 .highlight-thumb{ aspect-ratio:3/4; }
 
 /* ====== CTA band ====== */
@@ -495,9 +501,14 @@ section[id] .about-header, section[id] h3, section[id] h4{ scroll-margin-top:96p
 /* ================= Responsive switch ================= */
 @media (max-width:1100px){
   .tiles-quick{ grid-template-columns:1fr 1fr; }
-  .highlight-card{ grid-template-columns:1fr; }
-  .highlight-gallery{ grid-template-columns:repeat(2, minmax(0,1fr)); }
-  .highlight-hero{ grid-column:span 2; }
+  .highlight-card{
+    grid-template-columns:1fr;
+    grid-template-areas:
+      "copy"
+      "hero"
+      "gallery";
+  }
+  .highlight-hero{ min-height:300px; }
 }
 
 @media (max-width:960px){
@@ -525,7 +536,7 @@ section[id] .about-header, section[id] h3, section[id] h4{ scroll-margin-top:96p
 
 @media (max-width:700px){
   .highlight-gallery{ grid-template-columns:1fr; }
-  .highlight-hero{ grid-column:1; grid-row:auto; }
+  .highlight-hero{ min-height:260px; }
 }
 
 /* Highlight Join Us link */


### PR DESCRIPTION
## Summary
- move the Hopkins hero photo beside the copy and let the remaining shots span the full card width to eliminate dead space
- drop the recruitment tagline, keep the join/calendar chips, and make every highlight photo open in the existing lightbox
- add shared highlight photo styling so the gallery feels interactive on desktop and mobile breakpoints

## Testing
- Manual QA: `python3 -m http.server 8000`


------
https://chatgpt.com/codex/tasks/task_e_68e2b214f3bc8322aabb40ab83bbeee4