### PR TITLE
Add Brandeis and Fordham pending tournaments across site

### DIFF
--- a/index.html
+++ b/index.html
@@ -222,6 +222,7 @@
     .featured-side{ text-align:right; }
     .featured-side .pill{ display:inline-block; }
     .pill.tentative{ background:rgba(255,200,80,.12); border-color:rgba(255,200,80,.45); }
+    .pill.pending{ background:rgba(224,185,255,.16); border-color:rgba(224,185,255,.52); }
     @media (max-width: 960px){
       .featured-card{ grid-template-columns:1fr; text-align:left; }
       .featured-side{ text-align:left; }
@@ -571,6 +572,26 @@
           </div>
           <p class="event-meta">Oct 24–25 · Providence, RI</p>
           <p class="event-note">Details coming soon.</p>
+          <a class="link-chip" href="tournaments.html">Details →</a>
+        </article>
+
+        <article class="event-card">
+          <div class="event-head">
+            <h4>Brandeis</h4>
+            <span class="pill pending">Sign-ups pending</span>
+          </div>
+          <p class="event-meta">Sept 31–Oct 1 · Waltham, MA</p>
+          <p class="event-note">Details TBD — interest collection opens once the host packet drops.</p>
+          <a class="link-chip" href="tournaments.html">Details →</a>
+        </article>
+
+        <article class="event-card">
+          <div class="event-head">
+            <h4>Fordham</h4>
+            <span class="pill pending">Sign-ups pending</span>
+          </div>
+          <p class="event-meta">Nov 21–22 · Bronx, NY</p>
+          <p class="event-note">Details TBD — watch for sign-ups to post in Slack and at meetings.</p>
           <a class="link-chip" href="tournaments.html">Details →</a>
         </article>
       </div>

--- a/join.html
+++ b/join.html
@@ -415,7 +415,7 @@
           <ul>
             <li>Kickoff lessons begin</li>
             <li>First scrim night</li>
-              <li>Travel: Prep for Harvard (APDA Meeting) — Oct 10–11 in Cambridge. Roster confirmed; travel briefing during meetings.</li>
+            <li>Travel: Prep for Harvard (APDA Meeting) — Oct 10–11 in Cambridge (roster confirmed) and flag interest for Brandeis (Sept 31–Oct 1) — sign-ups pending host packet.</li>
           </ul>
           <div class="cta-row"><a class="link-chip" href="calendar.html">Open calendar →</a></div>
         </div>
@@ -423,7 +423,7 @@
           <h4>October</h4>
           <ul>
             <li>Casebuilding workshop</li>
-              <li>Travel: Harvard (APDA Meeting) — Oct 10–11 in Cambridge (roster & judging confirmed); Brown (tentative); Johns Hopkins recap shared in Highlights</li>
+            <li>Travel: Harvard (APDA Meeting) — Oct 10–11 in Cambridge (roster & judging confirmed); Brandeis (Sept 31–Oct 1) sign-ups pending; Brown (Oct 24–25) details TBD; Johns Hopkins recap shared in Highlights</li>
             <li>Novice spotlight night</li>
           </ul>
           <div class="cta-row"><a class="link-chip" href="calendar.html">Open calendar →</a></div>
@@ -432,7 +432,7 @@
           <h4>November</h4>
           <ul>
             <li>Mid-semester scrim series</li>
-              <li>Travel: TBD (placeholder)</li>
+            <li>Travel: Fordham (Nov 21–22) — sign-ups pending; details TBD until the host packet releases</li>
             <li>Judge training basics</li>
           </ul>
           <div class="cta-row"><a class="link-chip" href="calendar.html">Open calendar →</a></div>

--- a/members.html
+++ b/members.html
@@ -80,6 +80,8 @@
     .blink{ animation: blink 1s steps(2, start) infinite; }
     @keyframes blink{ 0%,50%{opacity:1;} 50%,100%{opacity:0;} }
 
+    .pill.pending{ background:rgba(224,185,255,.16); border-color:rgba(224,185,255,.52); }
+
     /* Tournaments overview: stronger separation for each entry */
     .targets-grid { gap: 16px; }
     .overview .target-card{
@@ -288,7 +290,7 @@
           <div class="dash-card accent-warn span-5">
             <h3 class="about-header" style="margin-top:.1rem;">Upcoming Travel  -  Overview</h3>
             <p class="about-preview" style="margin-bottom:.75rem;">
-              Next up: Harvard (APDA Meeting) — Oct 10–11 in Cambridge. Roster and judging are locked; Brown closes the month once details finalize. Huge thanks to everyone who wrapped Johns Hopkins Novice — recap incoming.
+              Next up: Harvard (APDA Meeting) — Oct 10–11 in Cambridge. Sign-ups are pending for Brandeis (Sept 31–Oct 1) and Fordham (Nov 21–22) while we wait on host packets, and Brown closes October once logistics finalize. Huge thanks to everyone who wrapped Johns Hopkins Novice — recap incoming.
             </p>
 
             <div class="targets-grid overview">
@@ -305,13 +307,13 @@
               </article>
 
               <article class="target-card">
-                <span class="pill passed">Passed</span>
-                <div class="chip-row"><span class="chip">Oct 3–4</span><span class="chip">Johns Hopkins Novice</span></div>
-                <h3>Johns Hopkins Recap</h3>
-                <p class="about-preview" style="margin:.55rem 0 .65rem;">Baltimore is in the books! Look for shout-outs in Recent Highlights and share photos for the drive.</p>
+                <span class="pill pending">Sign-ups pending</span>
+                <div class="chip-row"><span class="chip">Sept 31–Oct 1</span><span class="chip">Brandeis</span></div>
+                <h3>Brandeis</h3>
+                <p class="about-preview" style="margin:.55rem 0 .65rem;">Details TBD — we’ll collect interest once the host packet arrives. Let Education know if you’re eyeing the trip.</p>
                 <div class="cta-row">
-                  <a class="link-chip" href="index.html#recent-highlights">Highlights →</a>
-                  <a class="link-chip" href="tournaments.html#passed">Passed tournaments →</a>
+                  <a class="link-chip" href="tournaments.html">Details →</a>
+                  <a class="link-chip" href="calendar.html">Calendar →</a>
                 </div>
               </article>
 
@@ -323,6 +325,28 @@
                 <div class="cta-row">
                   <a class="link-chip" href="tournaments.html">Details →</a>
                   <a class="link-chip" href="calendar.html">Calendar →</a>
+                </div>
+              </article>
+
+              <article class="target-card">
+                <span class="pill pending">Sign-ups pending</span>
+                <div class="chip-row"><span class="chip">Nov 21–22</span><span class="chip">Fordham</span></div>
+                <h3>Fordham</h3>
+                <p class="about-preview" style="margin:.55rem 0 .65rem;">Details TBD — expect the invite closer to November. We’ll open the form once allocations land.</p>
+                <div class="cta-row">
+                  <a class="link-chip" href="tournaments.html">Details →</a>
+                  <a class="link-chip" href="calendar.html">Calendar →</a>
+                </div>
+              </article>
+
+              <article class="target-card">
+                <span class="pill passed">Passed</span>
+                <div class="chip-row"><span class="chip">Oct 3–4</span><span class="chip">Johns Hopkins Novice</span></div>
+                <h3>Johns Hopkins Recap</h3>
+                <p class="about-preview" style="margin:.55rem 0 .65rem;">Baltimore is in the books! Look for shout-outs in Recent Highlights and share photos for the drive.</p>
+                <div class="cta-row">
+                  <a class="link-chip" href="index.html#recent-highlights">Highlights →</a>
+                  <a class="link-chip" href="tournaments.html#passed">Passed tournaments →</a>
                 </div>
               </article>
             </div>
@@ -337,7 +361,7 @@
             <h4>October</h4>
             <ul>
               <li>Mon/Wed meetings · 7:00 PM</li>
-              <li>Travel: Harvard (APDA Meeting) — Oct 10–11 in Cambridge (roster & judging confirmed); Brown (tentative) later in the month; Johns Hopkins recap drops in Highlights</li>
+              <li>Travel: Harvard (APDA Meeting) — Oct 10–11 in Cambridge (roster & judging confirmed); Brandeis (Sept 31–Oct 1) sign-ups pending; Brown (Oct 24–25) details TBD; Johns Hopkins recap drops in Highlights</li>
             </ul>
             <div class="cta-row"><a class="link-chip" href="tournaments.html#october">See slate →</a></div>
           </div>
@@ -347,6 +371,7 @@
             <ul>
               <li>Busy travel window  -  plan ahead</li>
               <li>Rooming notes on Calendar events</li>
+              <li>Travel: Fordham (Nov 21–22) — sign-ups pending while details stay TBD</li>
             </ul>
             <div class="cta-row"><a class="link-chip" href="tournaments.html#november">See slate →</a></div>
           </div>

--- a/tournaments.html
+++ b/tournaments.html
@@ -39,6 +39,7 @@
     .pill.tentative  { background:rgba(255,200,80,.12);  border-color:rgba(255,200,80,.45); }
     .pill.confirmed  { background:rgba(120,180,255,.12); border-color:rgba(120,180,255,.45); }
     .pill.closed     { background:rgba(255,120,120,.14); border-color:rgba(255,120,120,.45); }
+    .pill.pending    { background:rgba(224,185,255,.16); border-color:rgba(224,185,255,.52); }
     .pill.passed     { background:rgba(180,180,200,.12); border-color:rgba(180,180,200,.35); }
 
     /* Featured tournament */
@@ -316,6 +317,31 @@
           </div>
         </article>
 
+        <!-- Brandeis -->
+        <article class="target-card" role="listitem">
+          <div class="event-head">
+            <h4>Brandeis</h4>
+            <span class="pill pending">Sign-ups pending</span>
+          </div>
+          <div class="event-badges">
+            <span class="badge-need" data-judges-needed="tbd" title="Estimated judges needed">
+              <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M7.5 7.5l4 4 5-5-4-4-5 5zm-1.4 1.4l-1.1 3.3 3.2-1.2 8-8-2.1-2.1-8 8zM3 21h18v-2H3v2z"/>
+              </svg>
+              <span class="badge-text">Judges needed: <strong class="need-count">TBD</strong></span>
+            </span>
+          </div>
+          <div class="meta">
+            <span class="chip">Brandeis University</span>
+            <span class="chip">Sept 31–Oct 1</span>
+          </div>
+          <p class="about-preview" style="margin:.25rem 0 .4rem;">Details TBD — the sign-up form opens once the host packet drops. Flag your interest at meetings in the meantime.</p>
+          <div class="cta-row">
+            <a class="link-chip" href="calendar.html">Calendar →</a>
+            <a class="link-chip" href="https://drive.google.com/drive/folders/1SIot57czQp_hxY6Bx38I_SN4deVhbvDo?usp=drive_link" target="_blank" rel="noopener">TID →</a>
+          </div>
+        </article>
+
         <!-- Brown -->
         <article class="target-card" role="listitem">
           <div class="event-head">
@@ -341,50 +367,25 @@
           </div>
         </article>
 
-        <!-- Sample: Sign-ups Open -->
+        <!-- Fordham -->
         <article class="target-card" role="listitem">
           <div class="event-head">
-            <h4>TBD</h4>
-            <span class="pill open">Sign-ups open</span>
+            <h4>Fordham</h4>
+            <span class="pill pending">Sign-ups pending</span>
           </div>
           <div class="event-badges">
-            <span class="badge-need" data-judges-needed="2" title="Estimated judges needed">
+            <span class="badge-need" data-judges-needed="tbd" title="Estimated judges needed">
               <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
                 <path d="M7.5 7.5l4 4 5-5-4-4-5 5zm-1.4 1.4l-1.1 3.3 3.2-1.2 8-8-2.1-2.1-8 8zM3 21h18v-2H3v2z"/>
               </svg>
-              <span class="badge-text">Judges needed: <strong class="need-count">2</strong></span>
+              <span class="badge-text">Judges needed: <strong class="need-count">TBD</strong></span>
             </span>
           </div>
           <div class="meta">
-            <span class="chip">Dates TBD</span>
+            <span class="chip">Fordham University</span>
+            <span class="chip">Nov 21–22</span>
           </div>
-          <p class="about-preview" style="margin:.25rem 0 .4rem;">Details to be announced.</p>
-          <div class="cta-row">
-            <a class="link-chip" href="#" title="Placeholder link for interest form" target="_blank" rel="noopener">Interest form →</a>
-            <a class="link-chip" href="calendar.html">Calendar →</a>
-            <a class="link-chip" href="https://drive.google.com/drive/folders/1SIot57czQp_hxY6Bx38I_SN4deVhbvDo?usp=drive_link" target="_blank" rel="noopener">TID →</a>
-          </div>
-          <p class="note">Sign up to debate <em>or</em> judge  -  choose your role in the form.</p>
-        </article>
-
-        <!-- Sample: Roster Confirmed -->
-        <article class="target-card" role="listitem">
-          <div class="event-head">
-            <h4>TBD</h4>
-            <span class="pill confirmed">Roster Confirmed</span>
-          </div>
-          <div class="event-badges">
-            <span class="badge-need" data-judges-needed="0" title="Estimated judges needed">
-              <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
-                <path d="M7.5 7.5l4 4 5-5-4-4-5 5zm-1.4 1.4l-1.1 3.3 3.2-1.2 8-8-2.1-2.1-8 8zM3 21h18v-2H3v2z"/>
-              </svg>
-              <span class="badge-text">Judges needed: <strong class="need-count">0</strong></span>
-            </span>
-          </div>
-          <div class="meta">
-            <span class="chip">Dates TBD</span>
-          </div>
-          <p class="about-preview" style="margin:.25rem 0 .4rem;">Details to be announced.</p>
+          <p class="about-preview" style="margin:.25rem 0 .4rem;">Details TBD — expect a host packet closer to the tournament. Interest sign-ups will open once we have allocations.</p>
           <div class="cta-row">
             <a class="link-chip" href="calendar.html">Calendar →</a>
             <a class="link-chip" href="https://drive.google.com/drive/folders/1SIot57czQp_hxY6Bx38I_SN4deVhbvDo?usp=drive_link" target="_blank" rel="noopener">TID →</a>


### PR DESCRIPTION
## Summary
- add Brandeis and Fordham as sign-ups pending tournaments with TBD details on the tournaments page
- surface the new pending tournaments on the home, members, and join pages so they appear in every upcoming overview

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e57c00902483228a838dcbbacaefa5