### PR TITLE
Update Brandeis tournament dates

### DIFF
--- a/index.html
+++ b/index.html
@@ -580,7 +580,7 @@
             <h4>Brandeis</h4>
             <span class="pill pending">Sign-ups pending</span>
           </div>
-          <p class="event-meta">Sept 31–Oct 1 · Waltham, MA</p>
+          <p class="event-meta">Oct 31–Nov 1 · Waltham, MA</p>
           <p class="event-note">Details TBD — interest collection opens once the host packet drops.</p>
           <a class="link-chip" href="tournaments.html">Details →</a>
         </article>

--- a/join.html
+++ b/join.html
@@ -415,7 +415,7 @@
           <ul>
             <li>Kickoff lessons begin</li>
             <li>First scrim night</li>
-            <li>Travel: Prep for Harvard (APDA Meeting) — Oct 10–11 in Cambridge (roster confirmed) and flag interest for Brandeis (Sept 31–Oct 1) — sign-ups pending host packet.</li>
+            <li>Travel: Prep for Harvard (APDA Meeting) — Oct 10–11 in Cambridge (roster confirmed) and flag interest for Brandeis (Oct 31–Nov 1) — sign-ups pending host packet.</li>
           </ul>
           <div class="cta-row"><a class="link-chip" href="calendar.html">Open calendar →</a></div>
         </div>
@@ -423,7 +423,7 @@
           <h4>October</h4>
           <ul>
             <li>Casebuilding workshop</li>
-            <li>Travel: Harvard (APDA Meeting) — Oct 10–11 in Cambridge (roster & judging confirmed); Brandeis (Sept 31–Oct 1) sign-ups pending; Brown (Oct 24–25) details TBD; Johns Hopkins recap shared in Highlights</li>
+            <li>Travel: Harvard (APDA Meeting) — Oct 10–11 in Cambridge (roster & judging confirmed); Brandeis (Oct 31–Nov 1) sign-ups pending; Brown (Oct 24–25) details TBD; Johns Hopkins recap shared in Highlights</li>
             <li>Novice spotlight night</li>
           </ul>
           <div class="cta-row"><a class="link-chip" href="calendar.html">Open calendar →</a></div>

--- a/members.html
+++ b/members.html
@@ -290,7 +290,7 @@
           <div class="dash-card accent-warn span-5">
             <h3 class="about-header" style="margin-top:.1rem;">Upcoming Travel  -  Overview</h3>
             <p class="about-preview" style="margin-bottom:.75rem;">
-              Next up: Harvard (APDA Meeting) — Oct 10–11 in Cambridge. Sign-ups are pending for Brandeis (Sept 31–Oct 1) and Fordham (Nov 21–22) while we wait on host packets, and Brown closes October once logistics finalize. Huge thanks to everyone who wrapped Johns Hopkins Novice — recap incoming.
+              Next up: Harvard (APDA Meeting) — Oct 10–11 in Cambridge. Sign-ups are pending for Brandeis (Oct 31–Nov 1) and Fordham (Nov 21–22) while we wait on host packets, and Brown closes October once logistics finalize. Huge thanks to everyone who wrapped Johns Hopkins Novice — recap incoming.
             </p>
 
             <div class="targets-grid overview">
@@ -308,7 +308,7 @@
 
               <article class="target-card">
                 <span class="pill pending">Sign-ups pending</span>
-                <div class="chip-row"><span class="chip">Sept 31–Oct 1</span><span class="chip">Brandeis</span></div>
+                <div class="chip-row"><span class="chip">Oct 31–Nov 1</span><span class="chip">Brandeis</span></div>
                 <h3>Brandeis</h3>
                 <p class="about-preview" style="margin:.55rem 0 .65rem;">Details TBD — we’ll collect interest once the host packet arrives. Let Education know if you’re eyeing the trip.</p>
                 <div class="cta-row">
@@ -361,7 +361,7 @@
             <h4>October</h4>
             <ul>
               <li>Mon/Wed meetings · 7:00 PM</li>
-              <li>Travel: Harvard (APDA Meeting) — Oct 10–11 in Cambridge (roster & judging confirmed); Brandeis (Sept 31–Oct 1) sign-ups pending; Brown (Oct 24–25) details TBD; Johns Hopkins recap drops in Highlights</li>
+              <li>Travel: Harvard (APDA Meeting) — Oct 10–11 in Cambridge (roster & judging confirmed); Brandeis (Oct 31–Nov 1) sign-ups pending; Brown (Oct 24–25) details TBD; Johns Hopkins recap drops in Highlights</li>
             </ul>
             <div class="cta-row"><a class="link-chip" href="tournaments.html#october">See slate →</a></div>
           </div>

--- a/tournaments.html
+++ b/tournaments.html
@@ -333,7 +333,7 @@
           </div>
           <div class="meta">
             <span class="chip">Brandeis University</span>
-            <span class="chip">Sept 31–Oct 1</span>
+            <span class="chip">Oct 31–Nov 1</span>
           </div>
           <p class="about-preview" style="margin:.25rem 0 .4rem;">Details TBD — the sign-up form opens once the host packet drops. Flag your interest at meetings in the meantime.</p>
           <div class="cta-row">


### PR DESCRIPTION
## Summary
- update Brandeis tournament listings to use the correct Oct 31–Nov 1 dates across the site

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5bdafe2348322ab05862562676bb8