### PR TITLE
Switch homepage to Spring break mode and publish new leadership

### DIFF
--- a/index.html
+++ b/index.html
@@ -525,8 +525,8 @@
     <div class="hero-overlay" aria-hidden="true"></div>
     <div class="hero-content glass-card reveal">
       <h1 class="hero-title">Welcome to PDU</h1>
-      <h2 class="hero-kicker">Spring 2026</h2>
-      <p class="hero-sub">The Parliamentary Debate Union is NYU’s premiere debate club, specializing in American Parliamentary Style.</p>
+      <h2 class="hero-kicker">Thank you for a great Spring 2026 semester</h2>
+      <p class="hero-sub">Congratulations to our newly elected leadership team, and thank you to everyone who made this season incredible. Stay tuned for Fall 2026 updates.</p>
       <div class="hero-ctas">
         <a class="btn-primary" href="https://docs.google.com/forms/d/e/1FAIpQLSftE0vf0Nd4kSeQlCfj6eTI9HnBrKXgAMVMU_faWM5XICtptw/viewform?usp=dialog" target="_blank" rel="noopener">Click here to Join!</a>
         <a class="btn-secondary" href="members.html">I’m Returning</a>
@@ -547,21 +547,21 @@
   <!-- Newcomer band -->
   <section class="band-newcomer" id="newcomers">
     <div class="n-body">
-      <h3>Start here: join at your own pace</h3>
-      <p>Weekly meetings: <strong>Mondays & Wednesdays, 7–9 PM ET</strong>. Mondays in <strong>John Paulson Center Room 243</strong>; Wednesdays in <strong>Global Center for Academic and Spiritual Life 284</strong>.</p>
+      <h3>Spring semester wrap-up</h3>
+      <p>Thank you for a fantastic Spring 2026. We are now in break mode and will share our Fall 2026 meeting schedule soon.</p>
       <div class="n-actions">
-        <a class="link-chip" href="https://docs.google.com/forms/d/e/1FAIpQLSftE0vf0Nd4kSeQlCfj6eTI9HnBrKXgAMVMU_faWM5XICtptw/viewform?usp=dialog" target="_blank" rel="noopener">Click here to Join!</a>
-        <a class="link-chip" href="beginner.html">Beginner Guide →</a>
-        <a class="link-chip calendar-spotlight" href="calendar.html">📅 Open the calendar →</a>
+        <a class="link-chip" href="leadership.html">Meet the new board →</a>
+        <a class="link-chip" href="join.html">Join mailing list →</a>
+        <a class="link-chip calendar-spotlight" href="calendar.html">📅 Stay tuned for Fall →</a>
       </div>
     </div>
     <div class="n-side">
       <div class="mini">
-        <span class="chip">Mon & Wed · 7–9 PM</span>
-        <span class="chip">Mon: Paulson 243</span>
-        <span class="chip">Wed: GCASL 284</span>
-        <span class="chip">Travel covered</span>
-        <span class="chip">No experience needed</span>
+        <span class="chip">Break mode</span>
+        <span class="chip">Election results posted</span>
+        <span class="chip">No upcoming tournaments</span>
+        <span class="chip">Fall updates soon</span>
+        <span class="chip">Stay tuned</span>
       </div>
     </div>
   </section>
@@ -594,7 +594,7 @@
         <ul>
           <li>Members dashboard & quick links</li>
           <li>Practice tools and drills</li>
-          <li>Upcoming tournaments</li>
+          <li>Fall season updates coming soon</li>
         </ul>
         <div class="path-actions">
           <a class="link-chip" href="members.html">Open Members →</a>
@@ -623,93 +623,32 @@
       </div>
     </section>
 
-    <!-- Featured tournament -->
+    <!-- Election announcement -->
     <section class="featured-wrap reveal" id="featured">
       <div class="featured-card">
         <div>
-          <h3 class="about-header" style="margin-bottom:.4rem;">Final tournament: Yale (Motions)</h3>
+          <h3 class="about-header" style="margin-bottom:.4rem;">Spring 2026 Election Results</h3>
           <div class="featured-meta">
-            <span class="chip">Deadline: Mar 13, 2026 · 11:59 PM ET (Self executing)</span>
-            <span class="chip">Yale University · New Haven, CT</span>
-            <span class="chip" data-signup-status="yale">Sign-ups open</span>
+            <span class="chip">President: Amish Gupta</span>
+            <span class="chip">Co-President: Cornelia Hsieh</span>
+            <span class="chip">Treasurer: Aemen Iqbal</span>
           </div>
-          <p class="about-preview" style="margin:.25rem 0 0;"><strong>Yale is our final tournament.</strong> Motions means no case prep is required.</p>
+          <p class="about-preview" style="margin:.25rem 0 0;"><strong>Operations:</strong> Veronica Leahy · <strong>Equity:</strong> Sofia Bocchino · <strong>Education:</strong> Nicole Chen · <strong>Marketing:</strong> Varsha Sripadham · <strong>Communications:</strong> Alexandra Giannousi.</p>
           <div class="cta-row" style="margin-top:.6rem;">
-            <a class="btn-primary" data-signup-link="yale" href="https://forms.gle/Y1LgyaEPKoCuJVgw5" target="_blank" rel="noopener">Open Yale Sign-Ups ↗</a>
-          </div>
-          <div class="cta-row" style="margin-top:.6rem;">
-            <a class="link-chip" href="tournaments.html">Tournaments →</a>
-            <a class="link-chip" href="calendar.html">Calendar →</a>
+            <a class="link-chip" href="leadership.html">Leadership page →</a>
+            <a class="link-chip" href="calendar.html">Stay tuned for Fall →</a>
           </div>
         </div>
         <div class="featured-side">
-          <span class="pill open">Final tournament</span>
+          <span class="pill pending">Break mode</span>
         </div>
       </div>
     </section>
-    <!-- Remaining tournament strip -->
-    <section class="section-wrap reveal" aria-label="Recent tournaments">
-      <h3 class="about-header">Tournament updates</h3>
-      <p class="muted" style="max-width:720px; margin:.5rem auto 1.1rem;">Spring 2026 updates: Yale is the final tournament and Northeastern is finalized.</p>
-      <div class="h-scroll">
-        <article class="event-card">
-          <div class="event-head">
-            <h4>Yale (Motions)</h4>
-            <span class="pill open" data-signup-status="yale">Open now</span>
-          </div>
-          <p class="event-meta">Apr 3–4 · Yale University, New Haven, CT</p>
-          <p class="event-note">Sign-ups close March 13, 2026 at 11:59 PM ET (Self executing).</p>
-          <div class="cta-row" style="gap:.4rem;">
-            <a class="btn-primary" data-signup-link="yale" href="https://forms.gle/Y1LgyaEPKoCuJVgw5" target="_blank" rel="noopener">Open sign-ups ↗</a>
-          </div>
-        </article>
-        <article class="event-card">
-          <div class="event-head">
-            <h4>Northeastern</h4>
-            <span class="pill pending">Finalized</span>
-          </div>
-          <p class="event-meta">Mar 27–28 · Northeastern University, Boston, MA</p>
-          <p class="event-note">Sign-ups are closed and pairings are confirmed.</p>
-          <div class="cta-row" style="gap:.4rem;">
-            <a class="link-chip" href="tournaments.html#partners">View pairings →</a>
-          </div>
-        </article>
-        <article class="event-card">
-          <div class="event-head">
-            <h4>Spring TBD</h4>
-            <span class="pill pending">Target</span>
-          </div>
-          <p class="event-meta">More events announced soon</p>
-          <p class="event-note">Subject to change.</p>
-          <div class="cta-row" style="gap:.4rem;">
-            <a class="link-chip" href="tournaments.html">Tournament page →</a>
-          </div>
-        </article>
-        <article class="event-card">
-          <div class="event-head">
-            <h4>Princeton (Motions)</h4>
-            <span class="pill pending">Target</span>
-          </div>
-          <p class="event-meta">Apr 10–11 · Details TBA</p>
-          <p class="event-note">Subject to change.</p>
-          <div class="cta-row" style="gap:.4rem;">
-            <a class="link-chip" href="tournaments.html">Tournament page →</a>
-          </div>
-        </article>
-        <article class="event-card">
-          <div class="event-head">
-            <h4>JHU Nationals</h4>
-            <span class="pill pending">Target</span>
-          </div>
-          <p class="event-meta">Apr 24–26 · Details TBA</p>
-          <p class="event-note">Subject to change.</p>
-          <div class="cta-row" style="gap:.4rem;">
-            <a class="link-chip" href="tournaments.html">Tournament page →</a>
-          </div>
-        </article>
-      </div>
+    <section class="section-wrap reveal" aria-label="Season status">
+      <h3 class="about-header">Season status</h3>
+      <p class="muted" style="max-width:720px; margin:.5rem auto 1.1rem;">All Spring tournaments are complete. We are now on break and preparing for Fall 2026.</p>
       <div class="cta-row">
-        <a class="link-chip" href="tournaments.html">See tournament details →</a>
+        <a class="link-chip" href="calendar.html">Check calendar for future updates →</a>
       </div>
     </section>
 

--- a/leadership.html
+++ b/leadership.html
@@ -359,14 +359,14 @@
 
       <button type="button" class="leader-card fade-in"
               aria-haspopup="dialog"
-              data-name="Rayan Sheikh"
+              data-name="Amish Gupta"
               data-role="President"
-              data-img="RayanHeadshot.jpeg"
-              data-email="rrs6697@nyu.edu"
-              data-bio="Rayan coordinates team strategy, outreach, and the competitive calendar - aligning training, travel, and culture across the season.">
-        <div class="leader-media"><img loading="lazy" src="RayanHeadshot.jpeg" alt="Portrait of Rayan Sheikh"></div>
+              data-img="Amish_Fall2026.jpg"
+              data-email="ag10490@nyu.edu"
+              data-bio="Amish leads NYU PDU’s strategy, training direction, and competitive vision for the 2026-27 season.">
+        <div class="leader-media"><img loading="lazy" src="Amish_Fall2026.jpg" alt="Portrait of Amish Gupta"></div>
         <div class="leader-info">
-          <h3 class="leader-name">Rayan Sheikh</h3>
+          <h3 class="leader-name">Amish Gupta</h3>
           <div class="leader-sep" aria-hidden="true"></div>
           <p class="leader-title">President</p>
         </div>
@@ -374,29 +374,44 @@
 
       <button type="button" class="leader-card fade-in"
               aria-haspopup="dialog"
-              data-name="Allen Liu"
-              data-role="President"
-              data-img="Allen(1).jpeg"
-              data-email="al8235@nyu.edu"
-              data-bio="Allen supports competitive development and represents PDU on the APDA circuit, aligning training with tournament goals.">
-        <div class="leader-media"><img loading="lazy" src="Allen(1).jpeg" alt="Portrait of Allen Liu"></div>
+              data-name="Cornelia Hsieh"
+              data-role="Co-President"
+              data-img="Cornelia_Fall2026.jpg"
+              data-email=""
+              data-bio="Cornelia serves as Co-President, helping coordinate team operations, outreach, and member development across the semester.">
+        <div class="leader-media"><img loading="lazy" src="Cornelia_Fall2026.jpg" alt="Portrait of Cornelia Hsieh"></div>
         <div class="leader-info">
-          <h3 class="leader-name">Allen Liu</h3>
+          <h3 class="leader-name">Cornelia Hsieh</h3>
           <div class="leader-sep" aria-hidden="true"></div>
-          <p class="leader-title">President</p>
+          <p class="leader-title">Co-President</p>
         </div>
       </button>
 
       <button type="button" class="leader-card fade-in"
               aria-haspopup="dialog"
-              data-name="Marcel Cato"
+              data-name="Aemen Iqbal"
+              data-role="Treasurer"
+              data-img="Aemen_Fall2026.jpg"
+              data-email=""
+              data-bio="Aemen oversees budgeting, funding, and financial logistics so members can compete without out-of-pocket costs.">
+        <div class="leader-media"><img loading="lazy" src="Aemen_Fall2026.jpg" alt="Portrait of Aemen Iqbal"></div>
+        <div class="leader-info">
+          <h3 class="leader-name">Aemen Iqbal</h3>
+          <div class="leader-sep" aria-hidden="true"></div>
+          <p class="leader-title">Treasurer</p>
+        </div>
+      </button>
+
+      <button type="button" class="leader-card fade-in"
+              aria-haspopup="dialog"
+              data-name="Veronica Leahy"
               data-role="Operations"
-              data-img="your-photo.jpg"
-              data-email="mac10121@nyu.edu"
-              data-bio="Travel, logistics, rosters, and TIDs - your point of contact for sign-ups, itineraries, and attendance.">
-        <div class="leader-media"><img loading="lazy" src="your-photo.jpg" alt="Portrait of Marcel Cato"></div>
+              data-img="Veronica_Fall2026.jpg"
+              data-email="vl2446@nyu.edu"
+              data-bio="Veronica coordinates travel, scheduling, logistics, and tournament execution to keep the team running smoothly.">
+        <div class="leader-media"><img loading="lazy" src="Veronica_Fall2026.jpg" alt="Portrait of Veronica Leahy"></div>
         <div class="leader-info">
-          <h3 class="leader-name">Marcel Cato</h3>
+          <h3 class="leader-name">Veronica Leahy</h3>
           <div class="leader-sep" aria-hidden="true"></div>
           <p class="leader-title">Operations</p>
         </div>
@@ -404,30 +419,15 @@
 
       <button type="button" class="leader-card fade-in"
               aria-haspopup="dialog"
-              data-name="Pranav Gupta"
-              data-role="Finance"
-              data-img="pranav.jpg"
-              data-email="pg2782@nyu.edu"
-              data-bio="Manages budgets and funding so members can focus on growing as debaters.">
-        <div class="leader-media"><img loading="lazy" src="pranav.jpg" alt="Portrait of Pranav Gupta"></div>
-        <div class="leader-info">
-          <h3 class="leader-name">Pranav Gupta</h3>
-          <div class="leader-sep" aria-hidden="true"></div>
-          <p class="leader-title">Finance</p>
-        </div>
-      </button>
-
-      <button type="button" class="leader-card fade-in"
-              aria-haspopup="dialog"
-              data-name="Dara Adebanjo"
+              data-name="Sofia Bocchino"
               data-role="Equity"
-              data-img="placeholder.jpg"
-              data-email="ooa328@nyu.edu"
-              data-bio="Confidential reports, team culture, and coordination with tournament Equity - ensuring challenging debate without harm.">
+              data-img="Sophia_Fall2026.jpg"
+              data-email=""
+              data-bio="Sofia leads equity initiatives, supports inclusive culture, and handles confidential concerns with care and responsiveness.">
         <span class="badge-equity">★ Equity</span>
-        <div class="leader-media"><img loading="lazy" src="placeholder.jpg" alt="Portrait of Dara Adebanjo"></div>
+        <div class="leader-media"><img loading="lazy" src="Sophia_Fall2026.jpg" alt="Portrait of Sofia Bocchino"></div>
         <div class="leader-info">
-          <h3 class="leader-name">Dara Adebanjo</h3>
+          <h3 class="leader-name">Sofia Bocchino</h3>
           <div class="leader-sep" aria-hidden="true"></div>
           <p class="leader-title">Equity</p>
         </div>
@@ -435,29 +435,29 @@
 
       <button type="button" class="leader-card fade-in"
               aria-haspopup="dialog"
-              data-name="Dedra Annakie"
-              data-role="Communications"
-              data-img="dedra.jpg"
-              data-email="Daa9713@nyu.edu"
-              data-bio="Manages internal communications, weekly updates, and channels that keep members connected and aligned across the club.">
-        <div class="leader-media"><img loading="lazy" src="dedra.jpg" alt="Portrait of Dedra Annakie"></div>
+              data-name="Nicole Chen"
+              data-role="Education"
+              data-img="Nicole_Fall2026.jpg"
+              data-email=""
+              data-bio="Nicole leads education programming, skill-building workshops, and feedback systems for debaters at every level.">
+        <div class="leader-media"><img loading="lazy" src="Nicole_Fall2026.jpg" alt="Portrait of Nicole Chen"></div>
         <div class="leader-info">
-          <h3 class="leader-name">Dedra Annakie</h3>
+          <h3 class="leader-name">Nicole Chen</h3>
           <div class="leader-sep" aria-hidden="true"></div>
-          <p class="leader-title">Communications</p>
+          <p class="leader-title">Education</p>
         </div>
       </button>
 
       <button type="button" class="leader-card fade-in"
               aria-haspopup="dialog"
-              data-name="Veronica Leahy"
+              data-name="Varsha Sripadham"
               data-role="Marketing"
-              data-img="VeroniciaHeadshot.jpeg"
-              data-email="vl2446@nyu.edu"
-              data-bio="Leads PDU's marketing voice across social media, celebrates team culture, and grows campus outreach through engaging campaigns and partnerships.">
-        <div class="leader-media"><img loading="lazy" src="VeroniciaHeadshot.jpeg" alt="Portrait of Veronica Leahy"></div>
+              data-img="Varsha_Fall2026.jpg"
+              data-email=""
+              data-bio="Varsha leads marketing, social media strategy, and campus outreach to grow NYU PDU’s visibility and engagement.">
+        <div class="leader-media"><img loading="lazy" src="Varsha_Fall2026.jpg" alt="Portrait of Varsha Sripadham"></div>
         <div class="leader-info">
-          <h3 class="leader-name">Veronica Leahy</h3>
+          <h3 class="leader-name">Varsha Sripadham</h3>
           <div class="leader-sep" aria-hidden="true"></div>
           <p class="leader-title">Marketing</p>
         </div>
@@ -465,16 +465,16 @@
 
       <button type="button" class="leader-card fade-in"
               aria-haspopup="dialog"
-              data-name="Amish Gupta"
-              data-role="Education"
-              data-img="amish.jpg"
-              data-email="ag10490@nyu.edu"
-              data-bio="Lessons, scrims, and feedback frameworks to help members grow at their own pace and prep for tournaments.">
-        <div class="leader-media"><img loading="lazy" src="amish.jpg" alt="Portrait of Amish Gupta"></div>
+              data-name="Alexandra Giannousi"
+              data-role="Communications"
+              data-img="Alexandra_Fall2026.jpg"
+              data-email=""
+              data-bio="Alexandra manages club communications, announcements, and member-facing updates across PDU channels.">
+        <div class="leader-media"><img loading="lazy" src="Alexandra_Fall2026.jpg" alt="Portrait of Alexandra Giannousi"></div>
         <div class="leader-info">
-          <h3 class="leader-name">Amish Gupta</h3>
+          <h3 class="leader-name">Alexandra Giannousi</h3>
           <div class="leader-sep" aria-hidden="true"></div>
-          <p class="leader-title">Education</p>
+          <p class="leader-title">Communications</p>
         </div>
       </button>
 


### PR DESCRIPTION
### Motivation
- Transition the site from an active Spring/tournament state to a wrap-up/break state and announce the newly elected executive board for visibility during the off-season.
- Replace tournament-focused homepage content that is no longer relevant and update leadership portraits and card metadata to reflect the election results.

### Description
- Updated `index.html` hero and subcopy to: “Thank you for a great Spring 2026 semester” and added break-mode messaging with “Stay tuned for Fall 2026”.
- Replaced the featured-tournament block with an election announcement listing the new officers and added a season-status section while removing the detailed upcoming tournament strip.
- Adjusted the newcomer / returning-members band and chips to break-mode wording and linked to the leadership page and mailing list.
- Replaced leadership cards in `leadership.html` with the new board members (President: Amish Gupta; Co-President: Cornelia Hsieh; Treasurer: Aemen Iqbal; Operations: Veronica Leahy; Equity: Sofia Bocchino; Education: Nicole Chen; Marketing: Varsha Sripadham; Communications: Alexandra Giannousi) and pointed each card to the repository portrait assets (e.g., `Amish_Fall2026.jpg`, `Cornelia_Fall2026.jpg`, etc.) and updated roles/bios.

### Testing
- Verified file presence and repository listing with `rg --files` and successful searches for target strings using `rg` which returned expected matches.
- Inspected the modified files with `sed -n` and paged outputs with `nl -ba` to confirm the updated sections appear in `index.html` and `leadership.html` as intended.
- Ran `git status --short` to confirm the working tree changes were present and verified the patch applied cleanly; no automated test suite is configured for this static site.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2bc79215c832294e596701fd09084)