### PR TITLE
Update Spring 2026 records: add tournaments and Executive Board results

### DIFF
--- a/records.html
+++ b/records.html
@@ -266,6 +266,21 @@
             <td>Feb 13–14</td>
             <td>2026</td>
           </tr>
+          <tr>
+            <td>Northeastern University</td>
+            <td>Mar 27–28</td>
+            <td>2026</td>
+          </tr>
+          <tr>
+            <td>Yale University</td>
+            <td>Apr 3–4</td>
+            <td>2026</td>
+          </tr>
+          <tr>
+            <td>Johns Hopkins Nationals</td>
+            <td>Apr 24–25</td>
+            <td>2026</td>
+          </tr>
         </tbody>
       </table>
       <h4 class="year-badge" style="margin-top:1.5rem;">Fall 2025</h4>
@@ -338,6 +353,18 @@
           <h4>Fall 2025 - Special Election</h4>
           <ul class="section-list">
             <li><strong>VP Marketing:</strong> Veronica Leahy</li>
+          </ul>
+        </div>
+        <div class="records-panel">
+          <h4>Spring 2026 - Executive Board Election</h4>
+          <ul class="section-list">
+            <li><strong>President:</strong> Amish Gupta</li>
+            <li><strong>Co-President:</strong> Cornelia Hsieh</li>
+            <li><strong>Treasurer:</strong> Aemen Iqbal</li>
+            <li><strong>VP Operations:</strong> Veronica Leahy</li>
+            <li><strong>VP Equity:</strong> Sofia Bocchino</li>
+            <li><strong>VP Education:</strong> Nicole Chen</li>
+            <li><strong>VP Marketing:</strong> Varsha Sripadham</li>
           </ul>
         </div>
         <div class="records-panel">


### PR DESCRIPTION
### Motivation
- Keep the internal records current for Spring 2026 by capturing recently completed tournament attendance and the outcome of the semester’s officer election.

### Description
- Updated `records.html` to add three Spring 2026 tournament rows: `Northeastern University` — Mar 27–28, 2026; `Yale University` — Apr 3–4, 2026; `Johns Hopkins Nationals` — Apr 24–25, 2026.
- Added a new "Spring 2026 - Executive Board Election" panel in the Past Election Results section listing: `President: Amish Gupta`, `Co-President: Cornelia Hsieh`, `Treasurer: Aemen Iqbal`, `VP Operations: Veronica Leahy`, `VP Equity: Sofia Bocchino`, `VP Education: Nicole Chen`, and `VP Marketing: Varsha Sripadham`.
- Left existing Fall 2025 and Spring 2025 records intact and preserved surrounding markup and styles.
- Single file modified: `records.html`.

### Testing
- Used `rg` to locate the Spring 2026 section and confirm context before and after edits.
- Ran the inline update script with `python` which reported `updated` to indicate the replacement completed successfully.
- Inspected the resulting file with `nl` and `sed` to verify the new table rows and the election panel appear at the expected lines.
- Performed a local repository inspection to confirm the file on disk reflects the changes and is ready for inclusion.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2c0e1d2b48322898bbd282f639039)