### PR TITLE
Add Passed Leadership archive page and navigation dropdown

### DIFF
--- a/about.html
+++ b/about.html
@@ -78,7 +78,13 @@
       </ul>
     </li>
 
-    <li><a href="leadership.html">Leadership</a></li>
+    <li class="has-submenu">
+      <a href="leadership.html" class="top-link">Leadership</a>
+      <ul class="submenu" role="menu" aria-label="Leadership submenu">
+        <li role="none"><a role="menuitem" href="leadership.html">Current Leadership</a></li>
+        <li role="none"><a role="menuitem" href="passed-leadership.html">Passed Leadership</a></li>
+      </ul>
+    </li>
     <li><a href="contact.html">Contact</a></li>
   </ul>
 </nav>
@@ -154,7 +160,13 @@
       </ul>
     </li>
 
-    <li><a href="leadership.html">Leadership</a></li>
+    <li class="has-submenu">
+      <a href="leadership.html" class="top-link">Leadership</a>
+      <ul class="submenu" role="menu" aria-label="Leadership submenu">
+        <li role="none"><a role="menuitem" href="leadership.html">Current Leadership</a></li>
+        <li role="none"><a role="menuitem" href="passed-leadership.html">Passed Leadership</a></li>
+      </ul>
+    </li>
     <li><a href="contact.html">Contact</a></li>
   </ul>
 </nav>

--- a/index.html
+++ b/index.html
@@ -428,7 +428,13 @@
             </ul>
           </li>
 
-          <li><a href="leadership.html">Leadership</a></li>
+          <li class="has-submenu">
+      <a href="leadership.html" class="top-link">Leadership</a>
+      <ul class="submenu" role="menu" aria-label="Leadership submenu">
+        <li role="none"><a role="menuitem" href="leadership.html">Current Leadership</a></li>
+        <li role="none"><a role="menuitem" href="passed-leadership.html">Passed Leadership</a></li>
+      </ul>
+    </li>
           <li><a href="contact.html">Contact</a></li>
         </ul>
       </nav>
@@ -502,7 +508,13 @@
           </ul>
         </li>
 
-        <li><a href="leadership.html">Leadership</a></li>
+        <li class="has-submenu">
+      <a href="leadership.html" class="top-link">Leadership</a>
+      <ul class="submenu" role="menu" aria-label="Leadership submenu">
+        <li role="none"><a role="menuitem" href="leadership.html">Current Leadership</a></li>
+        <li role="none"><a role="menuitem" href="passed-leadership.html">Passed Leadership</a></li>
+      </ul>
+    </li>
         <li><a href="contact.html">Contact</a></li>
       </ul>
     </nav>

--- a/leadership.html
+++ b/leadership.html
@@ -254,7 +254,13 @@
       </ul>
     </li>
 
-    <li><a href="leadership.html" aria-current="page">Leadership</a></li>
+    <li class="has-submenu">
+      <a href="leadership.html" class="top-link" aria-current="page">Leadership</a>
+      <ul class="submenu" role="menu" aria-label="Leadership submenu">
+        <li role="none"><a role="menuitem" href="leadership.html" aria-current="page">Current Leadership</a></li>
+        <li role="none"><a role="menuitem" href="passed-leadership.html">Passed Leadership</a></li>
+      </ul>
+    </li>
     <li><a href="contact.html">Contact</a></li>
   </ul>
 </nav>
@@ -330,7 +336,13 @@
       </ul>
     </li>
 
-    <li><a href="leadership.html" aria-current="page">Leadership</a></li>
+    <li class="has-submenu">
+      <a href="leadership.html" class="top-link" aria-current="page">Leadership</a>
+      <ul class="submenu" role="menu" aria-label="Leadership submenu">
+        <li role="none"><a role="menuitem" href="leadership.html" aria-current="page">Current Leadership</a></li>
+        <li role="none"><a role="menuitem" href="passed-leadership.html">Passed Leadership</a></li>
+      </ul>
+    </li>
     <li><a href="contact.html">Contact</a></li>
   </ul>
 </nav>
@@ -340,7 +352,10 @@
   <section class="hero-section hero-compact" id="leadersHero">
     <h1 class="page-title">Leadership</h1>
     <p class="page-subtitle">NYU Parliamentary Debate Union Executive Board</p>
-  </section>
+
+    <p class="fine-print"><a class="chip" href="passed-leadership.html">View Passed Leadership Archive</a></p>
+
+      </section>
 
   <!-- Glowing divider (kept) -->
   <div class="hero-divider" aria-hidden="true"></div>

--- a/passed-leadership.html
+++ b/passed-leadership.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Passed Leadership | NYU PDU</title>
+  <link rel="icon" type="image/png" href="PDUVIOLETWHITE.png">
+  <link rel="stylesheet" href="style.css" />
+  <meta name="description" content="Archived leadership for NYU PDU, beginning with the 2025-26 E-Board." />
+  <style>
+    .archive-wrap{max-width:1120px;margin:0 auto;padding:1.25rem;color:#fff}
+    .archive-hero{text-align:center;margin-bottom:1.5rem}
+    .archive-hero h1{font-family:"Newsreader",serif;font-size:clamp(2.2rem,5vw,3.4rem);margin:.2rem 0}
+    .archive-hero p{opacity:.92;margin:0}
+    .archive-block{background:rgba(255,255,255,.08);border:1px solid rgba(255,255,255,.22);border-radius:18px;padding:1rem 1rem 1.25rem;backdrop-filter:blur(10px);box-shadow:0 10px 30px rgba(0,0,0,.25)}
+    .archive-block h2{margin:.2rem 0 .15rem;font-family:"Newsreader",serif;font-size:1.7rem}
+    .archive-sub{opacity:.9;margin:0 0 1rem}
+    .leaders-grid{display:grid;gap:1rem;grid-template-columns:repeat(auto-fit,minmax(220px,1fr))}
+    .leader-card{overflow:hidden;border-radius:16px;background:rgba(33,12,64,.72);border:1px solid rgba(255,255,255,.2);box-shadow:0 8px 22px rgba(0,0,0,.3)}
+    .leader-media{aspect-ratio:4/5;background:#ddd}
+    .leader-media img{width:100%;height:100%;object-fit:cover;display:block}
+    .leader-info{text-align:center;padding:.65rem .75rem .9rem}
+    .leader-name{font-family:"Newsreader",serif;font-size:1.65rem;margin:0}
+    .leader-role,.leader-term{margin:.2rem 0 0;opacity:.95}
+    .archive-link{margin-top:1rem;display:flex;justify-content:center}
+    .archive-link a{color:#fff;text-decoration:none;border:1px solid rgba(255,255,255,.4);padding:.6rem 1rem;border-radius:999px;background:rgba(255,255,255,.08)}
+  </style>
+</head>
+<body>
+  <header class="glass-navbar" id="siteNavbar"></header>
+
+  <main class="archive-wrap">
+    <section class="archive-hero">
+      <h1>Passed Leadership</h1>
+      <p>NYU PDU archival leadership records.</p>
+    </section>
+
+    <section class="archive-block">
+      <h2>2025-26 E-Board</h2>
+      <p class="archive-sub">Term: 2025-2026</p>
+      <div class="leaders-grid">
+        <article class="leader-card"><div class="leader-media"><img src="RayanHeadshot.jpeg" alt="Rayan Sheikh portrait"></div><div class="leader-info"><h3 class="leader-name">Rayan Sheikh</h3><p class="leader-role">President</p><p class="leader-term">2025-2026</p></div></article>
+        <article class="leader-card"><div class="leader-media"><img src="Allen(1).jpeg" alt="Allen Liu portrait"></div><div class="leader-info"><h3 class="leader-name">Allen Liu</h3><p class="leader-role">President</p><p class="leader-term">2025-2026</p></div></article>
+        <article class="leader-card"><div class="leader-media"><img src="image000000.jpg" alt="Marcel Cato portrait"></div><div class="leader-info"><h3 class="leader-name">Marcel Cato</h3><p class="leader-role">Operations</p><p class="leader-term">2025-2026</p></div></article>
+        <article class="leader-card"><div class="leader-media"><img src="pranav.jpg" alt="Pranav Gupta portrait"></div><div class="leader-info"><h3 class="leader-name">Pranav Gupta</h3><p class="leader-role">Finance</p><p class="leader-term">2025-2026</p></div></article>
+        <article class="leader-card"><div class="leader-media"><img src="placeholder.jpg" alt="Placeholder portrait for Dara Adebanjo"></div><div class="leader-info"><h3 class="leader-name">Dara Adebanjo</h3><p class="leader-role">Equity</p><p class="leader-term">2025-2026</p></div></article>
+        <article class="leader-card"><div class="leader-media"><img src="dedra.jpg" alt="Dedra Annakie portrait"></div><div class="leader-info"><h3 class="leader-name">Dedra Annakie</h3><p class="leader-role">Communications</p><p class="leader-term">2025-2026</p></div></article>
+        <article class="leader-card"><div class="leader-media"><img src="VeroniciaHeadshot.jpeg" alt="Veronica Leahy portrait"></div><div class="leader-info"><h3 class="leader-name">Veronica Leahy</h3><p class="leader-role">Marketing</p><p class="leader-term">2025-2026</p></div></article>
+        <article class="leader-card"><div class="leader-media"><img src="amish.jpg" alt="Amish Gupta portrait"></div><div class="leader-info"><h3 class="leader-name">Amish Gupta</h3><p class="leader-role">Education</p><p class="leader-term">2025-2026</p></div></article>
+      </div>
+      <div class="archive-link"><a href="leadership.html">Back to current leadership</a></div>
+    </section>
+  </main>
+
+  <script src="assets/js/forms.js"></script>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide an archival page for prior officers starting with the 2025-26 E‑Board so the site maintains a clear record of past leadership.
- Surface the archive in primary navigation and on the current Leadership hero so visitors can discover both current and past leadership easily.

### Description
- Added `passed-leadership.html`, a dedicated archival page titled "Passed Leadership" with a styled card-grid for the **2025-26 E-Board** and term labels set to **2025-2026** for each card.
- Populated the archive cards using existing repository portrait assets and `placeholder.jpg` for Dara where requested.
- Converted the Leadership link into a dropdown submenu (items: `Current Leadership` and `Passed Leadership`) in `index.html`, `about.html`, and `leadership.html` (desktop and mobile/nav drawer sections).
- Added a visible archive call-to-action chip on the `leadership.html` hero linking to the new archive page.

### Testing
- Verified repository file listing with `rg --files` and inspected the current `leadership.html` hero with `sed -n '1,260p'` to determine insertion point, both commands succeeded.
- Ran `rg -n` checks for leader names and archive link patterns (e.g. `rg -n "Rayan|Allen|Marcel|Pranav|Dara|Dedra|Veronica|Amish|Leadership"` and `rg -n "passed-leadership|Leadership submenu|View Passed"`) to confirm updated content, and all searches returned expected hits.
- Confirmed new file contents with `nl -ba passed-leadership.html | sed -n '1,220p'` and inspected modified regions of `leadership.html`, `index.html`, and `about.html` using `nl -ba` to validate markup placement, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2c93cc13083229357e12193cfbdaa)